### PR TITLE
Support `Call()` to elsewhere in the sequence

### DIFF
--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -36,7 +36,7 @@ def qfunction(func):
 def qfunction_specialization(target):
         # QGL2 uses Call with a label, pointing elsewhere in the same
         # sequenece, wanting control passed there.
-        # It is not pointing to a function creating a sequence
+        # It is not pointing to a function creating a sequence.
         if target in qfunction_seq:
                 return qfunction_seq[target]
         else:

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -34,7 +34,14 @@ def qfunction(func):
 	return crfunc
 
 def qfunction_specialization(target):
-	return qfunction_seq[target]
+        # QGL2 uses Call with a label, pointing elsewhere in the same
+        # sequenece, wanting control passed there.
+        # It is not pointing to a function creating a sequence
+        if target in qfunction_seq:
+                return qfunction_seq[target]
+        else:
+                # QGL2 case
+                return list()
 
 @multimethod(int, Pulse)
 def repeat(n, p):

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -36,7 +36,9 @@ def qfunction(func):
 def qfunction_specialization(target):
         # QGL2 uses Call with a label, pointing elsewhere in the same
         # sequenece, wanting control passed there.
-        # It is not pointing to a function creating a sequence.
+        # In those cases, there was no qfunction registering
+        # a sequence that needs to be inserted; the pulses
+        # are already in a sequence, so are not in this hash.
         if target in qfunction_seq:
                 return qfunction_seq[target]
         else:


### PR DESCRIPTION
Modify `ControlFlow.qfunction_specialization()` to allow a `Call()` to pulses that are already elsewhere in the sequence, and not just to the return of a `@qfunction` decorated function, pulses that need to be inserted into the sequences.

The QGL2 compiler produces some QGL1 ControlFlow statements to handle loops and whatnot. To do this, we use `Call(BlockLabel('some label'))`

We produce code like this:
```
       Call(BlockLabel('repeat_start_20')),
       Goto(BlockLabel('repeat_end_20')),
       BlockLabel('repeat_start_20'),
       LoadRepeat(2),
       BlockLabel('repeat_loop_20'),
       Y90(QBIT_q1),
       Y90(QBIT_q1),
       MEAS(QBIT_q1),
       BlockLabel('repeat_repeat_20'),
       Repeat(BlockLabel('repeat_loop_20')),
       BlockLabel('repeat_return_20'),
       Return(),
       BlockLabel('repeat_end_20'),
```

`Call()` runs into a problem: the call to `Compiler.collect_specializations()`, which calls `ControlFlow.qfunction_specialization()`.
This code assumes you have generated a sequence with a function marked with the `@qfunction` decorator. And you are using this to point to a sequence. That is, the `@qfunction` decorator builds up a dictionary by label of sequences. Then the compiler looks up the label and puts those function definitions in at the beginning of the sequences (as a new sequence).

In comparison, we are using `Call()` to point to a label in the existing sequence, to pass control to that point. So there is no `@qfunction` decorator used and no sequence of pulses registered under that label. So there is no need to add the definition of the function being called using `Call()` to the sequences - it is already there.

So the proposal is to change `ControlFlow.qfunction_specialization()` to return an empty list of pulses if the given label does not refer to a known sequence, rather than produce an error.
