### PR TITLE
The sum of pulses differs with their amp or phase

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -89,7 +89,7 @@ def merge_channels(wires, channels):
 
                 newentry.phase = 0
 
-                pulsesHash = tuple([e.hashshape() for e in entries])
+                pulsesHash = tuple([tuple([e.hashshape()] + [e.amp] + [e.phase]) for e in entries])
                 if pulsesHash not in shapeFunLib:
                     # create closure to sum waveforms
                     def sum_shapes(entries=entries, **kwargs):


### PR DESCRIPTION
`hashshape()` only refers to the pulse shape, not amplitude or phase. The
sum of pulses with different amplitudes or phases produces a different
pulse shape, so it needs a new hash.