### PR TITLE
QGL2 multiqbit support: Allow selective adding slave trigger

### DIFF
--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -131,7 +131,7 @@ class Measurement(LogicalChannel):
     Measurements are special because they can be different types:
     autodyne which needs an IQ pair or hetero/homodyne which needs just a marker channel.
     '''
-    measType = Enum('autodyne','homodyne').tag(desc='Type of measurment (autodyne, homodyne)')
+    measType = Enum('autodyne','homodyne').tag(desc='Type of measurement (autodyne, homodyne)')
     autodyneFreq = Float(0.0).tag(desc='use to bake the modulation into the pulse, so that it has constant phase')
     frequency = Float(0.0).tag(desc='use frequency to asssociate modulation with the channel')
     pulseParams = Dict(default={'length':100e-9, 'amp':1.0, 'shapeFun':PulseShapes.tanh, 'cutoff':2, 'sigma':1e-9})

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -238,22 +238,29 @@ def collect_specializations(seqs):
         funcDefs += ControlFlow.qfunction_specialization(target)
     return funcDefs
 
-def compile_to_hardware(seqs, fileName, suffix='', qgl2=False):
+def compile_to_hardware(seqs, fileName, suffix='', qgl2=False, addQGL2SlaveTrigger=False):
     '''
     Compiles 'seqs' to a hardware description and saves it to 'fileName'. Other inputs:
         suffix : string to append to end of fileName (e.g. with fileNames = 'test' and suffix = 'foo' might save to test-APSfoo.h5)
     '''
     logger = logging.getLogger(__name__)
-    logger.debug("Add digitizer, blanking pulses, and slave trigger...")
+    logger.debug("Compiling %d sequence(s)", len(seqs))
 
-    # Add the digitizer trigger to measurements
-    PatternUtils.add_digitizer_trigger(seqs)
+    if not qgl2:
+        # Add the digitizer trigger to measurements
+        logger.debug("Adding digitizer")
+        PatternUtils.add_digitizer_trigger(seqs)
 
     # Add gating/blanking pulses
+    logger.debug("Adding blanking pulses")
     PatternUtils.add_gate_pulses(seqs)
 
-    # Add the slave trigger
-    PatternUtils.add_slave_trigger(seqs, ChannelLibrary.channelLib['slaveTrig'])
+    if not qgl2 or addQGL2SlaveTrigger:
+        # Add the slave trigger
+        logger.debug("Adding slave trigger")
+        PatternUtils.add_slave_trigger(seqs, ChannelLibrary.channelLib['slaveTrig'])
+    else:
+        logger.debug("Not adding slave trigger")
 
     # find channel set at top level to account for individual sequence channel variability
     channels = set([])

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -246,10 +246,9 @@ def compile_to_hardware(seqs, fileName, suffix='', qgl2=False, addQGL2SlaveTrigg
     logger = logging.getLogger(__name__)
     logger.debug("Compiling %d sequence(s)", len(seqs))
 
-    if not qgl2:
-        # Add the digitizer trigger to measurements
-        logger.debug("Adding digitizer")
-        PatternUtils.add_digitizer_trigger(seqs)
+    # Add the digitizer trigger to measurements
+    logger.debug("Adding digitizer")
+    PatternUtils.add_digitizer_trigger(seqs)
 
     # Add gating/blanking pulses
     logger.debug("Adding blanking pulses")
@@ -343,12 +342,12 @@ def compile_sequences(seqs, channels=None, qgl2=False):
     # all sequences should start with a WAIT
     for seq in seqs:
         if not isinstance(seq[0], ControlFlow.Wait):
-            logger.debug("Adding a Wait - first seq elem was %s", str(seq[0]))
+            logger.debug("Adding a WAIT - first sequence element was %s", str(seq[0]))
             seq.insert(0, ControlFlow.Wait())
     # turn into a loop, by appending GOTO(0) at end of last sequence
     if not isinstance(seqs[-1][-1], ControlFlow.Goto):
         seqs[-1].append(ControlFlow.Goto(BlockLabel.label(seqs[0])))
-        logger.debug("Appending a Goto at end to loop")
+        logger.debug("Appending a GOTO at end to loop")
 
     # inject function definitions prior to sequences
     funcDefs = collect_specializations(seqs)
@@ -373,7 +372,7 @@ def compile_sequences(seqs, channels=None, qgl2=False):
     # Debugging:
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug('')
-        logger.debug("Returning from compile_sequences:")
+        logger.debug("Returning from compile_sequences():")
         for chan in wireSeqs:
             logger.debug('')
             logger.debug("Channel '%s':", chan)
@@ -428,7 +427,7 @@ def compile_sequence(seq, channels=None):
                     wires[chan][-1] = copy(wires[chan][-1])
                     wires[chan][-1].frameChange += block.pulses[chan].frameChange
                     if chan in ChannelLibrary.channelLib.connectivityG.nodes():
-                        logger.debug("Doing propagate_node_frame_to_edges")
+                        logger.debug("Doing propagate_node_frame_to_edges()")
                         wires = propagate_node_frame_to_edges(wires, chan, block.pulses[chan].frameChange)
                 else:
                     warn("Dropping initial frame change")
@@ -440,7 +439,7 @@ def compile_sequence(seq, channels=None):
     if logger.isEnabledFor(logging.DEBUG):
         for chan in wires:
             logger.debug('')
-            logger.debug("compile_sequence Return for channel '%s':", chan)
+            logger.debug("compile_sequence() return for channel '%s':", chan)
             for elem in wires[chan]:
                 logger.debug(" %s", str(elem))
     return wires

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -45,12 +45,17 @@ def delay(sequences, delay):
 
 def normalize_delays(delays):
     '''
-    Normalizes a dictionary of channel delays. Postives delays shift right, negative delays shift left.
+    Normalizes a dictionary of channel delays. Postive delays shift right, negative delays shift left.
     Since we cannot delay by a negative amount in hardware, shift all delays until they are positive.
     Takes in a dict of channel:delay pairs and returns a normalized copy of the same.
     '''
-    min_delay = min(delays.values())
     out = dict(delays) # copy before modifying
+    if not out or len(out) == 0:
+        # Typically an error (empty sequence)
+        import logging
+        logging.error("normalize_delays() had no delays?")
+        return out
+    min_delay = min(delays.values())
     if min_delay < 0:
         for chan in delays.keys():
             out[chan] += -min_delay


### PR DESCRIPTION
To support QGL2 multi-qbit programs, add a flag to control whether to add a slave trigger.

For normal operations, no change. If you supply the qgl2 flag to `compile_to_hardware`, then you get no added slave trigger, unless you also add the new `addQGL2SlaveTrigger` flag. The result is that we only create the slave trigger for the program (single sequence) whose AWG is that of the slave trigger.

Also clean up log messages, and add an error check in 1 `PatternUtils` class.