### PR TITLE
Choose translator from file extension.

### DIFF
--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -39,12 +39,28 @@ def all_zero_seqs(seqs):
     return all([np.all(seq == 0) for seq in seqs])
 
 def build_awg_translator_map():
+    # TODO have this walk the drivers directory rather than pulling from the ChannelLibrary
     translators = {}
     for chan in ChannelLibrary.channelLib.values():
-        if (hasattr(chan, 'AWG') and chan.AWG and
-            hasattr(chan, 'translator') and chan.translator):
-            translators[chan.AWG] = import_module('QGL.drivers.'+chan.translator)
+        if hasattr(chan, 'translator') and chan.translator:
+            module = import_module('QGL.drivers.'+chan.translator)
+            ext = module.get_seq_file_extension()
+            if ext in translators:
+                translators[ext].append(module)
+            else:
+                translators[ext] = [module]
     return translators
+
+def resolve_translator(filename, translators):
+    ext = os.path.splitext(filename)[1]
+    if ext not in translators:
+        raise NameError("No translator found to open the given file %s", filename)
+    if len(translators[ext]) == 1:
+        return translators[ext][0]
+    for t in translators[ext]:
+        if t.is_compatible_file(filename):
+            return t
+    raise NameError("No translator found to open the given file %s", filename)
 
 def plot_pulse_files(fileNames):
     '''
@@ -72,7 +88,8 @@ def plot_pulse_files(fileNames):
 
         title += os.path.split(os.path.splitext(fileName)[0])[1] + "; "
 
-        wfs[AWGName] = translators[AWGName].read_sequence_file(fileName)
+        translator = resolve_translator(fileName, translators)
+        wfs[AWGName] = translator.read_sequence_file(fileName)
 
         for (k,seqs) in sorted(wfs[AWGName].items()):
             if not all_zero_seqs(seqs):

--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -71,6 +71,12 @@ def get_empty_channel_set():
 def get_seq_file_extension():
 	return '.h5'
 
+def is_compatible_file(filename):
+    with h5py.File(filename, 'r') as FID:
+        if FID['/'].attrs['target hardware'] == 'APS2':
+            return True
+    return False
+
 def create_wf_vector(wfLib):
 	'''
 	Helper function to create the wf vector and offsets into it.

--- a/QGL/drivers/APSPattern.py
+++ b/QGL/drivers/APSPattern.py
@@ -50,6 +50,12 @@ def get_empty_channel_set():
 def get_seq_file_extension():
     return '.h5'
 
+def is_compatible_file(filename):
+    with h5py.File(filename, 'r') as FID:
+        if FID['/'].attrs['target hardware'] == 'APS1':
+            return True
+    return False
+
 def preprocess(seqs, shapeLib, T):
 	seqs, miniLLrepeat = unroll_loops(seqs)
 	for seq in seqs:

--- a/QGL/drivers/TekPattern.py
+++ b/QGL/drivers/TekPattern.py
@@ -32,6 +32,13 @@ def get_empty_channel_set():
 def get_seq_file_extension():
     return '.awg'
 
+def is_compatible_file(filename):
+    import os
+    if os.path.splitext(filename)[1] == get_seq_file_extension():
+        return True
+    else:
+        return False
+
 def write_field(FID, fieldName, data, dataType):
     typeSizes = {'int16':2, 'int32':4, 'double':8, 'uint128':16}
     formatChars = {'int16':'<h', 'int32':'<i', 'double':'<d'}


### PR DESCRIPTION
Decouples ChannelLibrary setup from sequence file names, which is especially
handy when debuging test vectors. To get this to work, we need to handle the
fact that the APS1 and APS2 both use an h5 file extension. So, this also adds an
`is_compatible_file(filename)` method which drivers must define.