### PR TITLE
Simplify definition of MEAS, revise default CNOT to use an Edge

### DIFF
--- a/QGL/BasicSequences/Feedback.py
+++ b/QGL/BasicSequences/Feedback.py
@@ -53,14 +53,15 @@ def Reset(qubits, measDelay = 1e-6, signVec = None, doubleRound = True, buf = 20
 		signVec = (0,)*len(qubits)
 
 	seqs = [prep + [qreset(qubits, signVec, measDelay, buf)] for prep in create_cal_seqs(qubits,1)]
+	measBlock = reduce(operator.mul, [MEAS(q) for q in qubits])
 	if doubleRound:
 		for seq in seqs:
-			seq += [MEAS(*qubits)]
+			seq += [measBlock]
 			seq.append(qreset(qubits, signVec, measDelay, buf))
 
 	# add final measurement
 	for seq in seqs:
-		seq += [MEAS(*qubits), Id(qubits[0], measDelay), qwait('CMP')]
+		seq += [measBlock, Id(qubits[0], measDelay), qwait('CMP')]
 
 	if docals:
 		seqs += create_cal_seqs(qubits, calRepeats, measChans=measChans, waitcmp=True)

--- a/QGL/BasicSequences/RB.py
+++ b/QGL/BasicSequences/RB.py
@@ -20,7 +20,7 @@ def create_RB_seqs(numQubits, lengths, repeats=32, interleaveGate=None):
 	else:
 		raise Exception("Can only handle one or two qubits.")
 
-	#Create lists of of random integers 
+	#Create lists of of random integers
 	#Subtract one from length for recovery gate
 	seqs = []
 	for length in lengths:
@@ -45,18 +45,18 @@ def create_RB_seqs(numQubits, lengths, repeats=32, interleaveGate=None):
 def SingleQubitRB(qubit, seqs, showPlot=False):
 	"""
 
-	Single qubit randomized benchmarking using 90 and 180 generators. 
+	Single qubit randomized benchmarking using 90 and 180 generators.
 
 	Parameters
 	----------
-	qubit : logical channel to implement sequence (LogicalChannel) 
+	qubit : logical channel to implement sequence (LogicalChannel)
 	seqs : list of lists of Clifford group integers
 	showPlot : whether to plot (boolean)
 
 	Returns
 	-------
 	plotHandle : handle to plot window to prevent destruction
-	"""	
+	"""
 
 	seqsBis = []
 	for seq in seqs:
@@ -78,18 +78,18 @@ def SingleQubitRB(qubit, seqs, showPlot=False):
 def TwoQubitRB(q1, q2, seqs, showPlot=False, suffix=""):
 	"""
 
-	Two qubit randomized benchmarking using 90 and 180 single qubit generators and ZX90 
+	Two qubit randomized benchmarking using 90 and 180 single qubit generators and ZX90
 
 	Parameters
 	----------
-	qubit : logical channel to implement sequence (LogicalChannel) 
+	qubit : logical channel to implement sequence (LogicalChannel)
 	seqs : list of lists of Clifford group integers
 	showPlot : whether to plot (boolean)
 
 	Returns
 	-------
 	plotHandle : handle to plot window to prevent destruction
-	"""	
+	"""
 
 	seqsBis = []
 	for seq in seqs:
@@ -97,7 +97,7 @@ def TwoQubitRB(q1, q2, seqs, showPlot=False, suffix=""):
 
 	#Add the measurement to all sequences
 	for seq in seqsBis:
-		seq.append(MEAS(q1, q2))
+		seq.append(MEAS(q1) * MEAS(q2))
 
 	#Tack on the calibration sequences
 	seqsBis += create_cal_seqs((q1,q2), 2)
@@ -111,18 +111,18 @@ def TwoQubitRB(q1, q2, seqs, showPlot=False, suffix=""):
 def SingleQubitRB_AC(qubit, seqs, showPlot=False):
 	"""
 
-	Single qubit randomized benchmarking using atomic Clifford pulses. 
+	Single qubit randomized benchmarking using atomic Clifford pulses.
 
 	Parameters
 	----------
-	qubit : logical channel to implement sequence (LogicalChannel) 
+	qubit : logical channel to implement sequence (LogicalChannel)
 	seqFile : file containing sequence strings
 	showPlot : whether to plot (boolean)
 
 	Returns
 	-------
 	plotHandle : handle to plot window to prevent destruction
-	"""	
+	"""
 	seqsBis = []
 	for seq in seqs:
 		seqsBis.append([AC(qubit, c) for c in seq])
@@ -143,18 +143,18 @@ def SingleQubitRB_AC(qubit, seqs, showPlot=False):
 def SingleQubitIRB_AC(qubit, seqFile, showPlot=False):
 	"""
 
-	Single qubit interleaved randomized benchmarking using atomic Clifford pulses. 
+	Single qubit interleaved randomized benchmarking using atomic Clifford pulses.
 
 	Parameters
 	----------
-	qubit : logical channel to implement sequence (LogicalChannel) 
+	qubit : logical channel to implement sequence (LogicalChannel)
 	seqFile : file containing sequence strings
 	showPlot : whether to plot (boolean)
 
 	Returns
 	-------
 	plotHandle : handle to plot window to prevent destruction
-	"""	
+	"""
 	#Setup a pulse library
 	pulseLib = [AC(qubit, cliffNum) for cliffNum in range(24)]
 	pulseLib.append(pulseLib[0])
@@ -189,18 +189,18 @@ def SingleQubitIRB_AC(qubit, seqFile, showPlot=False):
 def SingleQubitRBT(qubit, seqFileDir, analyzedPulse, showPlot=False):
 	"""
 
-	Single qubit randomized benchmarking using atomic Clifford pulses. 
+	Single qubit randomized benchmarking using atomic Clifford pulses.
 
 	Parameters
 	----------
-	qubit : logical channel to implement sequence (LogicalChannel) 
+	qubit : logical channel to implement sequence (LogicalChannel)
 	seqFile : file containing sequence strings
 	showPlot : whether to plot (boolean)
 
 	Returns
 	-------
 	plotHandle : handle to plot window to prevent destruction
-	"""	
+	"""
 	#Setup a pulse library
 	pulseLib = [AC(qubit, cliffNum) for cliffNum in range(24)]
 	pulseLib.append(analyzedPulse)
@@ -236,11 +236,11 @@ def SingleQubitRBT(qubit, seqFileDir, analyzedPulse, showPlot=False):
 def SimultaneousRB_AC(qubits, seqs, showPlot=False):
 	"""
 
-	Simultaneous randomized benchmarking on multiple qubits using atomic Clifford pulses. 
+	Simultaneous randomized benchmarking on multiple qubits using atomic Clifford pulses.
 
 	Parameters
 	----------
-	qubits : iterable of logical channels to implement seqs on (list or tuple) 
+	qubits : iterable of logical channels to implement seqs on (list or tuple)
 	seqs : a tuple of sequences created for each qubit in qubits
 	showPlot : whether to plot (boolean)
 
@@ -251,7 +251,7 @@ def SimultaneousRB_AC(qubits, seqs, showPlot=False):
 	>>> seqs1 = create_RB_seqs(1, [2, 4, 8, 16])
 	>>> seqs2 = create_RB_seqs(1, [2, 4, 8, 16])
 	>>> SimultaneousRB_AC((q1, q2), (seqs1, seqs2), showPlot=False)
-	"""	
+	"""
 	seqsBis = []
 	for seq in zip(*seqs):
 		seqsBis.append([reduce(operator.__mul__, [AC(q,c) for q,c in zip(qubits,
@@ -269,4 +269,3 @@ def SimultaneousRB_AC(qubits, seqs, showPlot=False):
 
 	if showPlot:
 		plot_pulse_files(fileNames)
-

--- a/QGL/BasicSequences/Rabi.py
+++ b/QGL/BasicSequences/Rabi.py
@@ -77,7 +77,8 @@ def RabiAmp_NQubits(qubits, amps, phase=0, showPlot=False, measChans=None, docal
 	if measChans is None:
 		measChans = qubits
 
-	seqs = [[reduce(operator.mul, [Utheta(q, amp=amp, phase=phase) for q in qubits]),MEAS(*measChans)] for amp in amps]
+	measBlock = reduce(operator.mul, [MEAS(q) for q in qubits])
+	seqs = [[reduce(operator.mul, [Utheta(q, amp=amp, phase=phase) for q in qubits]), measBlock] for amp in amps]
 
 	if docals:
 		seqs += create_cal_seqs(qubits, calRepeats, measChans=measChans)

--- a/QGL/BasicSequences/helpers.py
+++ b/QGL/BasicSequences/helpers.py
@@ -10,7 +10,7 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False):
 
 	Parameters
 	----------
-	qubits : logical channels, e.g. (q1,) or (q1,q2) (tuple) 
+	qubits : logical channels, e.g. (q1,) or (q1,q2) (tuple)
 	numRepeats = number of times to repeat calibration sequences (int)
 	waitcmp = True if the sequence contains branching
 	"""
@@ -18,8 +18,9 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False):
 		measChans = qubits
 
 	calSet = [Id, X]
-	#Make all combination for qubit calibration states for n qubits and repeat 
+	#Make all combination for qubit calibration states for n qubits and repeat
 	calSeqs = [reduce(operator.mul, [p(q) for p,q in zip(pulseSet, qubits)]) for pulseSet in product(calSet, repeat=len(qubits)) for _ in range(numRepeats)]
 
-	#Add on the measurement operator. 
-	return [[seq, MEAS(*measChans), qwait('CMP')] if waitcmp else [seq, MEAS(*measChans)] for seq in calSeqs] 
+	#Add on the measurement operator.
+	measBlock = reduce(operator.mul, [MEAS(q) for q in qubits])
+	return [[seq, measBlock, qwait('CMP')] if waitcmp else [seq, measBlock] for seq in calSeqs]

--- a/QGL/Tomography.py
+++ b/QGL/Tomography.py
@@ -47,14 +47,15 @@ def state_tomo(seq, qubits, numPulses=4, measChans=None):
 	Parameters
 	-----------
 	seq : a single entry list sequence to perform tomography on
-	qubits : which qubits to act on 
+	qubits : which qubits to act on
 	numPulses : number of readout pulses
 	measChans : tuple of measurement channels to readout (defaults to individual qubit channels)
 	'''
 	if measChans is None:
 		measChans = qubits
-	
-	return [seq + [tomoBlock,  MEAS(*measChans)]
+	measBlock = reduce(operator.mul, [MEAS(q) for q in measChans])
+
+	return [seq + [tomoBlock,  measBlock]
 				 for tomoBlock in create_tomo_blocks(qubits, numPulses)]
 
 def process_tomo(seq, qubits, numPulses=4, measChans=None):
@@ -64,18 +65,18 @@ def process_tomo(seq, qubits, numPulses=4, measChans=None):
 	Parameters
 	-----------
 	seq : a single entry list sequence to perform tomography on
-	qubits : which qubits to act on 
+	qubits : which qubits to act on
 	numPulses : number of prep/readout pulses
 	measChans : tuple of measurement channels to readout (defaults to individual qubit channels)
 	'''
 	if measChans is None:
 		measChans = qubits
+	measBlock = reduce(operator.mul, [MEAS(q) for q in measChans])
 
 	seqs=[]
 	for k in range(numPulses**len(qubits)):
 		for readoutBlock in create_tomo_blocks(qubits, numPulses):
 			prepBlock = create_tomo_blocks(qubits,numPulses)[k]
-			tomoseq = [prepBlock] + seq + [readoutBlock, MEAS(*measChans)]
+			tomoseq = [prepBlock] + seq + [readoutBlock, measBlock]
 			seqs.append(tomoseq)
 	return seqs
-

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -122,7 +122,6 @@ class SingleQubitTestCases(SequenceTestCases):
         q1 = self.newQ1()
         self.sequences['ramsey'] = [[X90(q1), Id(q1, delay), X90(q1)] for delay in np.linspace(0.0, 1e-6, 11)]
 
-        q1 = self.newQ1()
         self.sequences['repeat'] = [X90(q1)] + repeat(5, Y(q1)) + [X90(q1)]
 
 class MultiQubitTestCases(SequenceTestCases):
@@ -137,16 +136,19 @@ class MultiQubitTestCases(SequenceTestCases):
         q2 = Qubit(label='q2')
         q2.pulseParams['length'] = 30e-9
         q2.physChan.samplingRate = 1.2e9
+        q1q2 = Edge(label='q1q2', source=q1, target=q2)
+        ChannelLibrary.channelLib.channelDict['q1'] = q1
+        ChannelLibrary.channelLib.channelDict['q2'] = q2
+        ChannelLibrary.channelLib.channelDict['q1q2'] = q1q2
+        ChannelLibrary.channelLib.build_connectivity_graph()
         return (q1,q2)
 
     def generate(self):
         q1, q2 = self.newQubits()
         self.sequences['operators'] = [X90(q1), X(q1)*Y(q2), CNOT(q1,q2), Xm(q2), Y(q1)*X(q2)]
 
-        q1, q2 = self.newQubits()
         self.sequences['align'] = [align(X90(q1)*Xtheta(q2, amp=0.5, length=100e-9), 'right'), Y90(q1)*Y90(q2)]
 
-        q1, q2 = self.newQubits()
         flipFlop = X(q1) + X(q1)
         self.sequences['composite'] = [align(flipFlop * Y(q2)), Y90(q1)]
 

--- a/tests/test_data/multi-operators.h5
+++ b/tests/test_data/multi-operators.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa61f537ddfff5f59ac74b35ddb36d4477932c8860fe2a28c2f33ad3f349d6cd
+oid sha256:c84ef386d4197706cf858dae034bfa8745a0c13ac626a6d68d995e5e0a070c27
 size 16448


### PR DESCRIPTION
After this, `MEAS` may only be called with a single positional argument. To get simultaneous measurement, you now need to write `MEAS(q1)*MEAS(q2)`, for example. The tuple input version for joint measurement has been removed.