### PR TITLE
Make str(Pulse) return enough information to reconstruct the object

### DIFF
--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -52,59 +52,61 @@ def Id(channel, *args, **kwargs):
     if len(args) > 0 and isinstance(args[0], (int,float)):
         params['length'] = args[0]
 
-    return TAPulse("Id", channel, params['length'], 0)
+    return TAPulse("Id", channel, params['length'], 0, ignoredStrParams=['amp', 'phase', 'frameChange'])
 
 # the most generic pulse is Utheta
-def Utheta(qubit, amp=0, phase=0, label='Utheta', **kwargs):
+def Utheta(qubit, amp=0, phase=0, label='Utheta', ignoredStrParams=[], **kwargs):
     '''  A generic rotation with variable amplitude and phase. '''
     params = overrideDefaults(qubit, kwargs)
-    return Pulse(label, qubit, params, amp, phase, 0.0)
+    return Pulse(label, qubit, params, amp, phase, 0.0, ignoredStrParams)
 
 # generic pulses around X, Y, and Z axes
-def Xtheta(qubit, amp=0, label='Xtheta', **kwargs):
+def Xtheta(qubit, amp=0, label='Xtheta', ignoredStrParams=[], **kwargs):
     '''  A generic X rotation with a variable amplitude  '''
-    return Utheta(qubit, amp, 0, label=label, **kwargs)
+    ignoredStrParams += ['phase', 'frameChange']
+    return Utheta(qubit, amp, 0, label, ignoredStrParams, **kwargs)
 
-def Ytheta(qubit, amp=0, label='Ytheta', **kwargs):
+def Ytheta(qubit, amp=0, label='Ytheta', ignoredStrParams=[], **kwargs):
     ''' A generic Y rotation with a variable amplitude '''
-    return Utheta(qubit, amp, pi/2, label=label, **kwargs)
+    ignoredStrParams += ['phase', 'frameChange']
+    return Utheta(qubit, amp, pi/2, label, ignoredStrParams, **kwargs)
 
-def Ztheta(qubit, angle=0, label='Ztheta', **kwargs):
+def Ztheta(qubit, angle=0, label='Ztheta', ignoredStrParams=['amp', 'phase', 'length'], **kwargs):
     # special cased because it can be done with a frame update
-    return TAPulse(label, qubit, length=0, amp=0, phase=0, frameChange=-angle)
+    return TAPulse(label, qubit, length=0, amp=0, phase=0, frameChange=-angle, ignoredStrParams=ignoredStrParams)
 
 #Setup the default 90/180 rotations
 # @_memoize
 def X(qubit, **kwargs):
-    return Xtheta(qubit, qubit.pulseParams['piAmp'], label="X", **kwargs)
+    return Xtheta(qubit, qubit.pulseParams['piAmp'], label="X", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def X90(qubit, **kwargs):
-    return Xtheta(qubit, qubit.pulseParams['pi2Amp'], label="X90", **kwargs)
+    return Xtheta(qubit, qubit.pulseParams['pi2Amp'], label="X90", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Xm(qubit, **kwargs):
-    return Xtheta(qubit, -qubit.pulseParams['piAmp'], label="Xm", **kwargs)
+    return Xtheta(qubit, -qubit.pulseParams['piAmp'], label="Xm", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def X90m(qubit, **kwargs):
-    return Xtheta(qubit, -qubit.pulseParams['pi2Amp'], label="X90m", **kwargs)
+    return Xtheta(qubit, -qubit.pulseParams['pi2Amp'], label="X90m", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Y(qubit, **kwargs):
-    return Ytheta(qubit, qubit.pulseParams['piAmp'], label="Y", **kwargs)
+    return Ytheta(qubit, qubit.pulseParams['piAmp'], label="Y", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Y90(qubit, **kwargs):
-    return Ytheta(qubit, qubit.pulseParams['pi2Amp'], label="Y90", **kwargs)
+    return Ytheta(qubit, qubit.pulseParams['pi2Amp'], label="Y90", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Ym(qubit, **kwargs):
-    return Ytheta(qubit, -qubit.pulseParams['piAmp'], label="Ym", **kwargs)
+    return Ytheta(qubit, -qubit.pulseParams['piAmp'], label="Ym", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Y90m(qubit, **kwargs):
-    return Ytheta(qubit, -qubit.pulseParams['pi2Amp'], label="Y90m", **kwargs)
+    return Ytheta(qubit, -qubit.pulseParams['pi2Amp'], label="Y90m", ignoredStrParams=['amp'], **kwargs)
 
 # @_memoize
 def Z(qubit, **kwargs):
@@ -121,11 +123,11 @@ def Z90m(qubit, **kwargs):
 # 90/180 degree rotations with control over the rotation axis
 def U90(qubit, phase=0, **kwargs):
     ''' A generic 90 degree rotation with variable phase. '''
-    return Utheta(qubit, qubit.pulseParams['pi2Amp'], phase, label="U90", **kwargs)
+    return Utheta(qubit, qubit.pulseParams['pi2Amp'], phase, label="U90", ignoredStrParams=['amp'], **kwargs)
 
 def U(qubit, phase=0, **kwargs):
     ''' A generic 180 degree rotation with variable phase.  '''
-    return Utheta(qubit, qubit.pulseParams['piAmp'], phase, label="U", **kwargs)
+    return Utheta(qubit, qubit.pulseParams['piAmp'], phase, label="U", ignoredStrParams=['amp'], **kwargs)
 
 def arb_axis_drag(qubit, nutFreq, rotAngle=0, polarAngle=0, aziAngle=0, **kwargs):
     """

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -70,13 +70,14 @@ class Pulse(object):
             self.isTimeAmp = True
 
     def __repr__(self):
-        return "Pulse({0}, {1}, {2}, {3}, {4}, {5})".format(
+        return "Pulse({0}, {1}, {2}, {3}, {4}, {5}, {6})".format(
             self.label,
             self.channel,
             self.shapeParams,
             self.amp,
             self.phase,
-            self.frameChange)
+            self.frameChange,
+            self.ignoredStrParams)
 
     def __str__(self):
         kwvals = []


### PR DESCRIPTION
Using the "algorithm" that @caryan and I came up with yesterday.

This solution is not universal, but it should work so long as `Pulse.label` is a valid pulse primitive name. Even within that domain there are some edge cases I am not handling, for instance `Ztheta` pulses will appear as `Ztheta(q1, frameChange=0.212)` even though the actual name of the keyword argument is `angle` and not `frameChange`. Also, autodyne `MEAS` pulses will appear with `MEAS(q1, amp=0.5, phase=0.0, shapeFun=<...autodyne...>)`. The `amp` and `phase` printing I can fix after we merge #46. I simply need to build `ignoredStrParams` based upon whether `amp` and `phase` are passed as kwargs. The `shapeFun` piece breaks my lookup algorithm because we swap `shapeFun` and `baseShape`, and `baseShape` is not in the channel parameters.

I haven't put any thought yet into the `arb_axis_drag` pulses since they break the convention of the label being a valid function name.