### PR TITLE
remove square pulse in favour of constant

### DIFF
--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -121,7 +121,7 @@ class LogicalMarkerChannel(LogicalChannel):
     '''
     A class for digital channels for gating sources or triggering other things.
     '''
-    pulseParams = Dict(default={'shapeFun': PulseShapes.square,
+    pulseParams = Dict(default={'shapeFun': PulseShapes.constant,
                                 'length': 10e-9})
 
 

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -104,8 +104,7 @@ def merge_channels(wires, channels):
             else:
                 frequency = 0.0
 
-            if all([(e.shapeParams['shapeFun'] == PulseShapes.constant or
-                    e.shapeParams['shapeFun'] == PulseShapes.square) for e in entries]):
+            if all([e.shapeParams['shapeFun'] == PulseShapes.constant for e in entries]):
                 phasor = np.sum([e.amp * np.exp(1j * e.phase) for e in entries])
                 amp = np.abs(phasor)
                 phase = np.angle(phasor)

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -434,10 +434,10 @@ def flat_top_gaussian(chan,
                       phase=0,
                       label="flat_top_gaussian"):
     """
-    A square pulse with rising and falling gaussian shape
+    A constant pulse with rising and falling gaussian shape
     """
     return Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOn, label=label+"_rise") + \
-           Utheta(chan, length=length, amp=amp, phase=phase, shapeFun=PulseShapes.square, label=label+"_top") + \
+           Utheta(chan, length=length, amp=amp, phase=phase, shapeFun=PulseShapes.constant, label=label+"_top") + \
            Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOff, label=label+"_fall")
 
 

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -44,8 +44,7 @@ class Pulse(namedtuple("Pulse", ["label", "channel", "amp", "phase", "frequency"
         for param in requiredParams:
             if param not in shapeParams.keys():
                 raise NameError("shapeParams must include {0}".format(param))
-        isTimeAmp = (shapeParams['shapeFun'] == PulseShapes.constant or
-                shapeParams['shapeFun'] == PulseShapes.square)
+        isTimeAmp = (shapeParams['shapeFun'] == PulseShapes.constant)
         isZero = (amp == 0)
         return super(cls, Pulse).__new__(cls, label, channel, amp, phase, frequency, frameChange, shapeParams, isTimeAmp, isZero, ignoredStrParams)
 

--- a/QGL/PulseShapes.py
+++ b/QGL/PulseShapes.py
@@ -8,7 +8,7 @@ from math import pi, sin, cos, acos, sqrt
 
 def gaussian(amp=1, length=0, cutoff=2, samplingRate=1e9, **params):
     '''
-    A simple gaussian shaped pulse. 
+    A simple gaussian shaped pulse.
     cutoff is how many sigma the pulse goes out
     '''
     #Round to how many points we need
@@ -17,15 +17,6 @@ def gaussian(amp=1, length=0, cutoff=2, samplingRate=1e9, **params):
     xStep = xPts[1] - xPts[0]
     return (amp * (np.exp(-0.5 * (xPts**2)) - np.exp(-0.5 * (
         (xPts[-1] + xStep)**2)))).astype(np.complex)
-
-
-def square(amp=1, length=0, samplingRate=1e9, **params):
-    '''
-    A simple rectangular shaped pulse. 
-    '''
-    #Round to how many points we need
-    numPts = np.round(length * samplingRate)
-    return (amp * np.ones(numPts)).astype(np.complex)
 
 
 def delay(length=0, samplingRate=1e9, **params):
@@ -42,6 +33,8 @@ def constant(amp=1, length=0, samplingRate=1e9, **params):
     numPts = np.round(length * samplingRate)
     return amp * np.ones(numPts, dtype=np.complex)
 
+# square is deprecated but alias square to constant
+square = constant
 
 def drag(amp=1,
          length=0,
@@ -134,7 +127,7 @@ def dragGaussOff(amp=1,
 
 def tanh(amp=1, length=0, sigma=0, cutoff=2, samplingRate=1e9, **params):
     '''
-    A rounded square shape from the sum of two tanh shapes. 
+    A rounded constant shape from the sum of two tanh shapes.
     '''
     numPts = np.round(length * samplingRate)
     xPts = np.linspace(-length / 2, length / 2, numPts)


### PR DESCRIPTION
The names `square` or `constant` make assumptions about what is before or after and having a single pulse shape for "constant" pulses simplifies some TimeAmp checks. Leaving an alias from `square` -> `constant` should silently update ChannelParams files.