### PR TITLE
Copy PulseBlock one layer deeper

### DIFF
--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -202,7 +202,7 @@ class PulseBlock(object):
 
         # copy PulseBlock so we don't modify other references
         result = copy(self)
-
+        result.pulses = copy(self.pulses)
         for (k, v) in rhs.pulses.items():
             if k in result.pulses.keys():
                 raise NameError(


### PR DESCRIPTION
Apparently this line is still necessary, even with namedtuples.
This fixes
`state_tomo([X(q1)*X(q2), qubits=(q1,)])`
with q2 in a slave APS. Otherwise the slave trigger tries to get attached to the ''same'' pulse block for every segment