### PR TITLE
Enable 2nd NCO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 *.json
+*.awg
+*-code.py
+*.h5

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -517,8 +517,12 @@ def compile_sequence(seq, channels=None):
                     warn("Dropping initial frame change")
                     continue
                 logger.debug("Modifying pulse on %s: %s", chan, wires[chan][-1])
-                updated_frameChange = wires[chan][-1].frameChange + block.pulses[chan].frameChange
-                wires[chan][-1] = wires[chan][-1]._replace(frameChange=updated_frameChange)
+                # search for last non-TA entry
+                for ct in range(1,len(wires[chan])):
+                    if not wires[chan][-ct].isTimeAmp:
+                        updated_frameChange = wires[chan][-ct].frameChange + block.pulses[chan].frameChange
+                        wires[chan][-ct] = wires[chan][-ct]._replace(frameChange=updated_frameChange)
+                        break
                 if chan in ChannelLibrary.channelLib.connectivityG.nodes():
                     logger.debug("Doing propagate_node_frame_to_edges()")
                     wires = propagate_node_frame_to_edges(

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -66,10 +66,10 @@ def merge_channels(wires, channels):
     mergedWire = [[] for _ in range(len(wires[chan]))]
     shapeFunLib = {}
     for ct, segment in enumerate(mergedWire):
-        entryIterators = [iter(wires[ch][ct]) for ch in channels]
+        entry_iterators = [iter(wires[ch][ct]) for ch in channels]
         while True:
             try:
-                entries = [next(e) for e in entryIterators]
+                entries = [next(e) for e in entry_iterators]
             except StopIteration:
                 break
             # control flow on any channel should pass thru
@@ -82,15 +82,11 @@ def merge_channels(wires, channels):
                 segment.append(entries[0])
                 continue
             # at this point we have at least one waveform instruction
-            blocklength = pull_uniform_entries(entries, entryIterators)
+            entries, block_length = pull_uniform_entries(entries, entry_iterators)
 
             # look for the simplest case of at most one non-identity
-            nonZeroEntries = [e for e in entries if not e.isZero]
-            if len(nonZeroEntries) == 0:
-                segment.append(entries[0])
-                continue
-            elif len(nonZeroEntries) == 1:
-                segment.append(nonZeroEntries[0])
+            if len(entries) == 1:
+                segment.extend(entries[0])
                 continue
 
             # create a new Pulse object for the merged pulse
@@ -103,7 +99,7 @@ def merge_channels(wires, channels):
             if nonZeroSSBChan:
                 frequency = entries[nonZeroSSBChan[0]].frequency
             else:
-                frequency = 0.0
+                frequency = 0.0  
 
             if all([e.shapeParams['shapeFun'] == PulseShapes.constant for e in entries]):
                 phasor = np.sum([e.amp * np.exp(1j * e.phase) for e in entries])
@@ -123,7 +119,7 @@ def merge_channels(wires, channels):
                     shapeFunLib[pulsesHash] = sum_shapes
                 shapeFun = shapeFunLib[pulsesHash]
 
-            shapeParams = {"shapeFun": shapeFun, "length": blocklength}
+            shapeParams = {"shapeFun": shapeFun, "length": block_length}
 
             label = "*".join([e.label for e in entries])
             segment.append(Pulse(label, entries[0].channel, shapeParams, amp, phase))
@@ -131,7 +127,7 @@ def merge_channels(wires, channels):
     return mergedWire
 
 
-def pull_uniform_entries(entries, entryIterators):
+def pull_uniform_entries(entries, entry_iterators):
     '''
     Given entries from a set of logical channels (that share a physical
     channel), pull enough entries from each channel so that the total pulse
@@ -148,29 +144,43 @@ def pull_uniform_entries(entries, entryIterators):
     #keep track of how many entry iterators are used up
     iterDone = [ False ] * numChan
     ct = 0
+    lengths = [e.length for e in entries]
+    entries_stack = [[e] for e in entries]
+
     while True:
         #If we've used up all the entries on all the channels we're done
         if all(iterDone):
             raise StopIteration("Unable to find a uniform set of entries")
 
-        #If all the entry lengths are the same we are finished
-        entryLengths = [e.length for e in entries]
-        if all(x == entryLengths[0] for x in entryLengths):
+        if all(x == lengths[0] for x in lengths):
             break
 
         #Otherwise try to concatenate on entries to match lengths
-        while entries[ct].length < max(e.length for e in entries):
+        while lengths[ct] < max(lengths):
             # concatenate with following entry to make up the length difference
             try:
-                nextentry = next(entryIterators[ct])
+                next_entry = next(entry_iterators[ct])
             except StopIteration:
                 iterDone[ct] = True
 
-            entries[ct] = concatenate_entries(entries[ct], nextentry)
+            entries_stack[ct].append(next_entry)
+            lengths[ct] += next_entry.length
 
         ct = (ct + 1) % numChan
 
-    return max(e.length for e in entries)
+
+    #if we have all zeros or a single non zero we return that as a list of entries
+    allzero_chan = [all([e.isZero for e in stack]) for stack in entries_stack ]
+    if all(allzero_chan):
+        entries = [ entries_stack[0] ]
+    elif np.sum(allzero_chan) == len(entries) - 1:
+        entries = [ entries_stack[allzero_chan.index(False)] ]
+    else:
+        entries = []
+        for stack in entries_stack:
+            entries.append( reduce(concatenate_entries, stack) )
+
+    return entries, max(lengths)
 
 
 def concatenate_entries(entry1, entry2):

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -77,6 +77,11 @@ def Utheta(qubit,
            **kwargs):
     '''  A generic rotation with variable amplitude and phase. '''
     params = overrideDefaults(qubit, kwargs)
+        #amp and phase are now pulse parameters rather than shape parameters
+    if "amp" in params:
+      del params["amp"]
+    if "phase" in params:
+      del params["phase"]
     return Pulse(label, qubit, params, amp, phase, 0.0, ignoredStrParams)
 
 

--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -543,7 +543,8 @@ def inject_modulation_cmds(seqs):
 					if entry.length > 0:
 						mod_seq.append(entry)
 						# if we have a modulate waveform modulate pattern and there is no pending frame update we can append length to previous modulation command
-						if (len(mod_seq) > 1) and (isinstance(mod_seq[-1], Compiler.Waveform)) and (isinstance(mod_seq[-2], ModulationCommand)) and (mod_seq[-2].instruction == "MODULATE") and not pending_frame_update:
+						if (len(mod_seq) > 1) and (isinstance(mod_seq[-1], Compiler.Waveform)) and (isinstance(mod_seq[-2], ModulationCommand)) and (mod_seq[-2].instruction == "MODULATE") \
+						and mod_seq[-1].frequency == cur_freq and not pending_frame_update:
 							mod_seq[-2].length += entry.length
 						else:
 							mod_seq.append( ModulationCommand("MODULATE", nco_select, length=entry.length))

--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -527,7 +527,7 @@ def inject_modulation_cmds(seqs):
 				if not no_modulation_cmds:
 					#insert phase and frequency commands before modulation command so they have the same start time
 					phase_freq_cmds = []
-					if cur_freq != entry.frequency:
+					if cur_freq != entry.frequency and not entry.isTimeAmp:
 						if nco_select == 0x1 and cur_freq!=0:
 							nco_select = 0x2
 						else:

--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -527,7 +527,7 @@ def inject_modulation_cmds(seqs):
 				if not no_modulation_cmds:
 					#insert phase and frequency commands before modulation command so they have the same start time
 					phase_freq_cmds = []
-					if cur_freq != entry.frequency and not entry.isTimeAmp:
+					if cur_freq != entry.frequency and (not entry.isTimeAmp or cur_freq==0):
 						if nco_select == 0x1 and cur_freq!=0:
 							nco_select = 0x2
 						else:

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -81,9 +81,9 @@ class CompileUtils(unittest.TestCase):
         ll = Compiler.compile_sequence(seq)
         entryIterators = [iter(ll[q1]), iter(ll[q2])]
         entries = [next(e) for e in entryIterators]
-        blocklen = Compiler.pull_uniform_entries(entries, entryIterators)
-        self.assertAlmostEqual(blocklen, 60e-9)
-        assert all(e.length == blocklen for e in entries)
+        entries, max_length = Compiler.pull_uniform_entries(entries, entryIterators)
+        self.assertAlmostEqual(max_length, 60e-9)
+        assert all(e.length == max_length for e in entries)
         self.assertRaises(StopIteration, next, entryIterators[0])
 
         q2.pulseParams['length'] = 40e-9
@@ -91,9 +91,9 @@ class CompileUtils(unittest.TestCase):
         ll = Compiler.compile_sequence(seq)
         entryIterators = [iter(ll[q1]), iter(ll[q2])]
         entries = [next(e) for e in entryIterators]
-        blocklen = Compiler.pull_uniform_entries(entries, entryIterators)
-        self.assertAlmostEqual(blocklen, 40e-9)
-        assert all(e.length == blocklen for e in entries)
+        entries, max_length = Compiler.pull_uniform_entries(entries, entryIterators)
+        self.assertAlmostEqual(max_length, 40e-9)
+        assert all(e.length == max_length for e in entries)
 
     def test_pull_uniform_entries2(self):
         q1 = self.q1
@@ -104,9 +104,9 @@ class CompileUtils(unittest.TestCase):
         ll = Compiler.compile_sequence(seq)
         entryIterators = [iter(ll[q1]), iter(ll[q2])]
         entries = [next(e) for e in entryIterators]
-        blocklen = Compiler.pull_uniform_entries(entries, entryIterators)
-        self.assertAlmostEqual(blocklen, 120e-9)
-        self.assertTrue(all(e.length == blocklen for e in entries))
+        entries, max_length = Compiler.pull_uniform_entries(entries, entryIterators)
+        self.assertAlmostEqual(max_length, 120e-9)
+        self.assertTrue(all(e.length == max_length for e in entries))
 
     def test_merge_channels(self):
         q1 = self.q1

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -418,11 +418,23 @@ class TestAPS2(unittest.TestCase, APS2Helper, TestSequences):
         APS2Helper.__init__(self)
         APS2Helper.setUp(self)
 
+    def test_mux_CR(self):
+        #control and CR sharing the same chans
+        self.channels['cr'].physChan = self.channels['q1'].physChan
+        self.channels['q1'].frequency = 100e6 
+        self.channels['cr'].frequency = 200e6
+        ChannelLibrary.channelLib.build_connectivity_graph()
+        seqs = [CNOT_CR(self.q1, self.q2)]
+
+        filenames = compile_to_hardware(seqs, 'CNOT_CR_mux/CNOT_CR_mux')
+        self.compare_sequences('CNOT_CR_mux')
+
+
     @unittest.expectedFailure
     def test_misc_seqs1(self):
         """
 		Fails to do nutFreq being set to a very small value (5.0) for the
-		arb_axis_drag pulse causing a large waveform ampliutde. Previously this
+		arb_axis_drag pulse causing a large waveform amplitude. Previously this
 		got phase shifted and then clipped so both chA and chB were railed. With
 		onboard modulation it gets clipped and then rotated.
 		"""
@@ -611,6 +623,10 @@ class TestTek5014(unittest.TestCase, AWGTestHelper, TestSequences):
     @unittest.expectedFailure
     def test_misc_seqs4(self):
         TestSequences.test_misc_seqs4(self)
+
+    @unittest.expectedFailure
+    def test_mux_CR(self):
+        TestSequences.test_mux_CR(self)
 
     @unittest.expectedFailure
     def test_AllXY(self):

--- a/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS1.h5
+++ b/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS1.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f89d866262e1108f94fe3b621cb63fc6fb1f1122aa529485e91f8d7dd9c6027
+size 10664

--- a/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS3.h5
+++ b/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS3.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f2f29870fe5b48fc2aec6c71862480002c35a2319defead5c396b0fb82d394
+size 10664

--- a/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS5.h5
+++ b/tests/test_data/awg/TestAPS2/CNOT_CR_mux/CNOT_CR_mux-APS5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0ac7aa3a92d7cd3662b23ab746a32b963e554479c6826d7774f69726bb42e9
+size 10664


### PR DESCRIPTION
Switches to 2nd NCO when modulation frequency is different from the previous pulse.
For example, to switch between qubit and CR drive on the same APS.
Only working for max 2 frequencies. 
