### PR TITLE
fix AC in-place waveform update

### DIFF
--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -49,6 +49,7 @@ def _memoize(pulseFunc):
 
     return cacheWrap
 
+
 @_memoize
 def Id(channel, *args, **kwargs):
     '''
@@ -198,21 +199,23 @@ def Z90m(qubit, **kwargs):
 
 # 90/180 degree rotations with control over the rotation axis
 def U90(qubit, phase=0, **kwargs):
-    ''' A generic 90 degree rotation with variable phase. '''
+    """ A generic 90 degree rotation with variable phase. """
+    if "label" not in kwargs:
+        kwargs["label"] = "U90"
     return Utheta(qubit,
                   qubit.pulseParams['pi2Amp'],
                   phase,
-                  label="U90",
                   ignoredStrParams=['amp'],
                   **kwargs)
 
 
 def U(qubit, phase=0, **kwargs):
-    ''' A generic 180 degree rotation with variable phase.  '''
+    """ A generic 180 degree rotation with variable phase.  """
+    if "label" not in kwargs:
+        kwargs["label"] = "U"
     return Utheta(qubit,
                   qubit.pulseParams['piAmp'],
                   phase,
-                  label="U",
                   ignoredStrParams=['amp'],
                   **kwargs)
 
@@ -274,7 +277,8 @@ def arb_axis_drag(qubit,
     params['rotAngle'] = rotAngle
     params['polarAngle'] = polarAngle
     params['shapeFun'] = PulseShapes.arb_axis_drag
-    return Pulse("ArbAxis", qubit, params, 1.0, aziAngle, frameChange)
+    return Pulse(kwargs["label"] if "label" in kwargs else "ArbAxis", qubit,
+                 params, 1.0, aziAngle, frameChange)
 
 
 def AC(qubit, cliffNum):
@@ -330,90 +334,105 @@ def AC(qubit, cliffNum):
         return Z90m(qubit)
     elif cliffNum == 10:
         #X+Y 180
-        return U(qubit, phase=pi / 4)
+        return U(qubit, phase=pi / 4, label="AC_10")
     elif cliffNum == 11:
         #X-Y 180
-        return U(qubit, phase=-pi / 4)
+        return U(qubit, phase=-pi / 4, label="AC_11")
     elif cliffNum == 12:
         #X+Z 180(Hadamard)
-        return arb_axis_drag(qubit, nutFreq, rotAngle=pi, polarAngle=pi / 4)
+        return arb_axis_drag(qubit,
+                             nutFreq,
+                             rotAngle=pi,
+                             polarAngle=pi / 4,
+                             label="AC_12")
     elif cliffNum == 13:
         #X-Z 180
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=pi,
                              polarAngle=pi / 4,
-                             aziAngle=pi)
+                             aziAngle=pi,
+                             label="AC_13")
     elif cliffNum == 14:
         #Y+Z 180
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=pi,
                              polarAngle=pi / 4,
-                             aziAngle=pi / 2)
+                             aziAngle=pi / 2,
+                             label="AC_14")
     elif cliffNum == 15:
         #Y-Z 180
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=pi,
                              polarAngle=pi / 4,
-                             aziAngle=-pi / 2)
+                             aziAngle=-pi / 2,
+                             label="AC_15")
     elif cliffNum == 16:
         #X+Y+Z 120
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=acos(1 / sqrt(3)),
-                             aziAngle=pi / 4)
+                             aziAngle=pi / 4,
+                             label="AC_16")
     elif cliffNum == 17:
         #X+Y+Z -120 (equivalent to -X-Y-Z 120)
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=pi - acos(1 / sqrt(3)),
-                             aziAngle=5 * pi / 4)
+                             aziAngle=5 * pi / 4,
+                             label="AC_17")
     elif cliffNum == 18:
         #X-Y+Z 120
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=acos(1 / sqrt(3)),
-                             aziAngle=-pi / 4)
+                             aziAngle=-pi / 4,
+                             label="AC_18")
     elif cliffNum == 19:
         #X-Y+Z 120 (equivalent to -X+Y-Z 120)
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=pi - acos(1 / sqrt(3)),
-                             aziAngle=3 * pi / 4)
+                             aziAngle=3 * pi / 4,
+                             label="AC_19")
     elif cliffNum == 20:
         #X+Y-Z 120
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=pi - acos(1 / sqrt(3)),
-                             aziAngle=pi / 4)
+                             aziAngle=pi / 4,
+                             label="AC_20")
     elif cliffNum == 21:
         #X+Y-Z -120 (equivalent to -X-Y+Z 120)
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=acos(1 / sqrt(3)),
-                             aziAngle=5 * pi / 4)
+                             aziAngle=5 * pi / 4,
+                             label="AC_21")
     elif cliffNum == 22:
         #-X+Y+Z 120
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=acos(1 / sqrt(3)),
-                             aziAngle=3 * pi / 4)
+                             aziAngle=3 * pi / 4,
+                             label="AC_22")
     elif cliffNum == 23:
         #-X+Y+Z -120 (equivalent to X-Y-Z 120)
         return arb_axis_drag(qubit,
                              nutFreq,
                              rotAngle=2 * pi / 3,
                              polarAngle=pi - acos(1 / sqrt(3)),
-                             aziAngle=-pi / 4)
+                             aziAngle=-pi / 4,
+                             label="AC_23")
     else:
         raise ValueError('Clifford number must be between 0 and 23')
 

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -49,6 +49,8 @@ def _memoize(pulseFunc):
 
     return cacheWrap
 
+def clear_pulse_cache():
+    _memoize.cache = {}
 
 @_memoize
 def Id(channel, *args, **kwargs):


### PR DESCRIPTION
With pulse memoization turned on be sure to clear the pulse cache and recreate pulses before updating. I've added a helper `PulsePrimitives.clear_pulse_cache` to make it easier to dig out.

e.g.

```python
Python 3.5.2 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:53:06) 
Type "copyright", "credits" or "license" for more information.

IPython 4.2.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from QGL import *

In [2]: q1 = QubitFactory("q1")

In [3]: pulse_lib = [AC(q1, ct) for ct in range(24)]

In [4]: seqs = [[pulse_lib[np.random.randint(24)] for _ in range(10)]]

In [5]: from QGL.drivers import APS2Pattern

In [6]: APS2Pattern.SAVE_WF_OFFSETS = True

In [7]: files = compile_to_hardware(seqs, "Test/Test")
Compiled 1 sequences.

In [8]: q1.pulseParams["pi2Amp"] = 0.25

In [9]: PulsePrimitives.c
PulsePrimitives.clear_pulse_cache  PulsePrimitives.cos                

In [9]: PulsePrimitives.clear_pulse_cache()

In [10]: pulse_lib = [AC(q1, ct) for ct in range(24)]

In [11]: PatternUtils.up
PatternUtils.update_pulse_length  PatternUtils.update_wf_library    

In [11]: PatternUtils.update_wf_library(pulse_lib, "/home/cryan/Programming/Repos/QGL/awg/Test/Test")
Updating pulses for BBNAPS1
	Y90m(q1) not found in offsets so skipping
	Z90m(q1, frameChange=1.5707963267948966) not found in offsets so skipping
	Updating X(q1) at offset 24
	Z(q1, frameChange=-3.141592653589793) not found in offsets so skipping
	AC_14(q1, amp=1.0, phase=1.5707963267948966, frameChange=-2.2214414690791826, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	Updating AC_23(q1, amp=1.0, phase=-0.7853981633974483, frameChange=1.2091995761561447, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) at offset 96
	Updating AC_21(q1, amp=1.0, phase=3.9269908169872414, frameChange=-1.209199576156145, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) at offset 0
	AC_17(q1, amp=1.0, phase=3.9269908169872414, frameChange=1.2091995761561447, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	X90(q1) not found in offsets so skipping
	AC_15(q1, amp=1.0, phase=-1.5707963267948966, frameChange=-2.2214414690791826, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	AC_16(q1, amp=1.0, phase=0.7853981633974483, frameChange=-1.209199576156145, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	Id(q1, length=0) not found in offsets so skipping
	AC_18(q1, amp=1.0, phase=-0.7853981633974483, frameChange=-1.209199576156145, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	Y(q1) not found in offsets so skipping
	X90m(q1) not found in offsets so skipping
	Z90(q1, frameChange=-1.5707963267948966) not found in offsets so skipping
	Updating AC_22(q1, amp=1.0, phase=2.356194490192345, frameChange=-1.209199576156145, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) at offset 168
	AC_13(q1, amp=1.0, phase=3.141592653589793, frameChange=-2.2214414690791826, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping
	Updating AC_12(q1, amp=1.0, phase=0, frameChange=-2.2214414690791826, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) at offset 144
	Updating AC_19(q1, amp=1.0, phase=2.356194490192345, frameChange=1.2091995761561447, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) at offset 48
	Updating Y90(q1) at offset 120
	Updating AC_10(q1, phase=0.7853981633974483, frameChange=0.0) at offset 72
	AC_11(q1, phase=-0.7853981633974483, frameChange=0.0) not found in offsets so skipping
	AC_20(q1, amp=1.0, phase=0.7853981633974483, frameChange=1.2091995761561447, shapeFun=<function arb_axis_drag at 0x7f97d25e98c8>) not found in offsets so skipping

In [12]: 


```