### PR TITLE
Cavity reset pulse

### DIFF
--- a/QGL/BasicSequences/__init__.py
+++ b/QGL/BasicSequences/__init__.py
@@ -4,7 +4,7 @@ from .FlipFlop import FlipFlop
 from .SPAM import SPAM
 from .RB import create_RB_seqs, SingleQubitRB, SingleQubitRB_AC, SingleQubitIRB_AC, SimultaneousRB_AC, SingleQubitRBT, TwoQubitRB
 from .Decoupling import HahnEcho, CPMG
-from .helpers import create_cal_seqs
+from .helpers import create_cal_seqs, time_descriptor, cal_descriptor
 from .CR import EchoCRPhase, EchoCRLen, EchoCRAmp, PiRabi
 from .AllXY import AllXY
 from .Feedback import Reset

--- a/QGL/BasicSequences/helpers.py
+++ b/QGL/BasicSequences/helpers.py
@@ -22,14 +22,17 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False, delay=Non
 
     calSet = [Id, X]
     #Make all combination for qubit calibration states for n qubits and repeat
-    calSeqs = [reduce(operator.mul, [p(q) for p, q in zip(pulseSet, qubits)])
+    cal_seqs = [reduce(operator.mul, [p(q) for p, q in zip(pulseSet, qubits)])
                for pulseSet in product(calSet, repeat=len(qubits))
                for _ in range(numRepeats)]
 
     #Add on the measurement operator.
     measBlock = reduce(operator.mul, [MEAS(q) for q in qubits])
-    return [[seq, Id(qubits[0], delay), measBlock, qwait('CMP')] if waitcmp else [seq, Id(qubits[0], delay), measBlock]
-            for seq in calSeqs]
+    #Add optional delay
+    full_cal_seqs = [[seq, Id(qubits[0], delay), measBlock] if delay else [seq, measBlock] for seq in cal_seqs]
+    if waitcmp:
+        [cal_seq.append(qwait('CMP')) for cal_seq in full_cal_seqs]
+    return full_cal_seqs
 
 def cal_descriptor(qubits, numRepeats):
     states = ['0', '1']

--- a/QGL/BasicSequences/helpers.py
+++ b/QGL/BasicSequences/helpers.py
@@ -6,8 +6,7 @@ from ..PulsePrimitives import Id, X, MEAS
 from ..ControlFlow import qwait
 from functools import reduce
 
-
-def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False):
+def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False, delay=None):
     """
 	Helper function to create a set of calibration sequences.
 
@@ -16,6 +15,7 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False):
 	qubits : logical channels, e.g. (q1,) or (q1,q2) (tuple)
 	numRepeats = number of times to repeat calibration sequences (int)
 	waitcmp = True if the sequence contains branching
+    delay: optional time between state preparation and measurement (s)
 	"""
     if measChans is None:
         measChans = qubits
@@ -28,7 +28,7 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False):
 
     #Add on the measurement operator.
     measBlock = reduce(operator.mul, [MEAS(q) for q in qubits])
-    return [[seq, measBlock, qwait('CMP')] if waitcmp else [seq, measBlock]
+    return [[seq, Id(qubits[0], delay), measBlock, qwait('CMP')] if waitcmp else [seq, Id(qubits[0], delay), measBlock]
             for seq in calSeqs]
 
 def cal_descriptor(qubits, numRepeats):

--- a/QGL/PulseShapes.py
+++ b/QGL/PulseShapes.py
@@ -144,8 +144,25 @@ def measPulse(amp=1, length=0, sigma=0, samplingRate=1e9, **params):
     """
     numPts = np.round(length * samplingRate)
     timePts = (1.0 / samplingRate) * np.arange(numPts)
-    return amp * (0.8 * np.exp(-timePts / sigma) + 0.2).astype(np.complex)
+    return amp * (0.6 * np.exp(-timePts / sigma) + 0.4).astype(np.complex)
 
+def CLEAR(amp=1, length=0, sigma=0, samplingRate=1e9, **params):
+    """
+    Pulse shape to quickly deplete the cavity at the end of a measurement.
+    measPulse followed by 2 steps of length step_length and amplitudes amp1, amp2.
+    """
+    if 'amp1' not in params:
+        params['amp1'] = 0
+    if 'amp2' not in params:
+        params['amp2'] = 0
+    if 'step_length' not in params:
+        params['step_length'] = 100e-9
+    timePts = (1.0 / samplingRate) * np.arange(np.round((length-2*params['step_length']) * samplingRate))
+    flat_step = amp * (0.6 * np.exp(-timePts / sigma) + 0.4).astype(np.complex)
+    numPts_clear_step = np.round(params['step_length'] * samplingRate)
+    clear_step_one = amp * params['amp1'] * np.ones(numPts_clear_step, dtype=np.complex)
+    clear_step_two = amp * params['amp2'] * np.ones(numPts_clear_step, dtype=np.complex)
+    return np.append(flat_step, [clear_step_one, clear_step_two])
 
 def autodyne(frequency=10e6, baseShape=constant, **params):
     '''


### PR DESCRIPTION
Two-step cavity reset pulse. Used by https://github.com/BBN-Q/Qlab/pull/91
The CLEAR pulse shape has additional parameters: `step_length`, `amp1`, `amp2` for the length of each of the two reset steps, and their relative amplitudes. 