### PR TITLE
Propagate frame change to first non-TA pulse

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -644,9 +644,12 @@ def propagate_node_frame_to_edges(wires, chan, frameChange):
         edge = ChannelLibrary.channelLib.connectivityG.edge[predecessor][chan][
             'channel']
         if edge in wires:
-            updated_frameChange = wires[edge][-1].frameChange + frameChange
-            wires[edge][-1] = wires[edge][-1]._replace(frameChange=updated_frameChange)
-
+            # search for last non-TA entry
+            for ct in range(1,len(wires[edge])):
+                if hasattr(wires[edge][-ct], 'isTimeAmp') and not wires[edge][-ct].isTimeAmp:
+                    updated_frameChange = wires[edge][-ct].frameChange + frameChange
+                    wires[edge][-ct] = wires[edge][-ct]._replace(frameChange=updated_frameChange)
+                    break
     return wires
 
 

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -599,6 +599,14 @@ def compile_sequence(seq, channels=None, edgesToCompile=None, qubitToCompile=Non
             for chan in channels:
                 wires[chan] += [copy(block)]
             continue
+        # propagate frame change from nodes to edges
+        for chan in channels:
+            if block.pulses[chan].frameChange == 0:
+                continue
+            if chan in ChannelLibrary.channelLib.connectivityG.nodes():
+                logger.debug("Doing propagate_node_frame_to_edges()")
+                wires = propagate_node_frame_to_edges(
+                    wires, chan, block.pulses[chan].frameChange)
         # drop length 0 blocks but push nonzero frame changes onto previous entries
         if block.length == 0:
             for chan in channels:
@@ -614,11 +622,6 @@ def compile_sequence(seq, channels=None, edgesToCompile=None, qubitToCompile=Non
                         updated_frameChange = wires[chan][-ct].frameChange + block.pulses[chan].frameChange
                         wires[chan][-ct] = wires[chan][-ct]._replace(frameChange=updated_frameChange)
                         break
-                if chan in ChannelLibrary.channelLib.connectivityG.nodes():
-                    logger.debug("Doing propagate_node_frame_to_edges()")
-                    wires = propagate_node_frame_to_edges(
-                        wires, chan, block.pulses[chan].frameChange)
-
             continue
 
         # schedule the block


### PR DESCRIPTION
Fix frame-update propagation for CR gates, analogously to single-qubit gates in https://github.com/BBN-Q/QGL/pull/74/commits/7d4b0b9ffc5b9b3f4742b1512b1043ad4fe811da
