### PR TITLE
Add ReceiverChannels

### DIFF
--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -41,6 +41,9 @@ class ChannelLibrary(Atom):
     fileWatcher = Typed(FileWatcher.LibraryFileWatcher)
     version = Int(5)
 
+    specialParams = ['physChan', 'gateChan', 'trigChan', 'receiverChan',
+                     'source', 'target']
+
     def __init__(self, channelDict={}, **kwargs):
         super(ChannelLibrary, self).__init__(channelDict=channelDict, **kwargs)
         self.connectivityG = nx.DiGraph()
@@ -99,43 +102,30 @@ class ChannelLibrary(Atom):
         return {"channelDict": self.channelDict, "version": self.version}
 
     def load_from_library(self):
-        if self.libFile:
-            try:
-                with open(self.libFile, 'r') as FID:
-                    tmpLib = json.load(FID, cls=ChannelDecoder)
-                    if not isinstance(tmpLib, ChannelLibrary):
-                        raise ValueError('Failed to load channel library')
+        if not self.libFile:
+            return
+        try:
+            FID = open(self.libFile, 'r')
+            tmpLib = json.load(FID, cls=ChannelDecoder)
+            FID.close()
+            if not isinstance(tmpLib, ChannelLibrary):
+                raise ValueError('Failed to load channel library')
 
-                    # connect objects labeled by strings
-                    for chan in tmpLib.channelDict.values():
-                        if hasattr(chan, 'physChan'):
-                            chan.physChan = tmpLib[
-                                chan.
-                                physChan] if chan.physChan in tmpLib.channelDict else None
-                        if hasattr(chan, 'gateChan'):
-                            chan.gateChan = tmpLib[
-                                chan.
-                                gateChan] if chan.gateChan in tmpLib.channelDict else None
-                        if hasattr(chan, 'trigChan'):
-                            chan.trigChan = tmpLib[
-                                chan.
-                                trigChan] if chan.trigChan in tmpLib.channelDict else None
-                        if hasattr(chan, 'source'):
-                            chan.source = tmpLib[
-                                chan.
-                                source] if chan.source in tmpLib.channelDict else None
-                        if hasattr(chan, 'target'):
-                            chan.target = tmpLib[
-                                chan.
-                                target] if chan.target in tmpLib.channelDict else None
-                    self.channelDict.update(tmpLib.channelDict)
-                    # grab library version
-                    self.version = tmpLib.version
-                    self.build_connectivity_graph()
-            except IOError:
-                print('No channel library found.')
-            except ValueError:
-                print('Failed to load channel library.')
+            # connect objects labeled by strings
+            for chan in tmpLib.channelDict.values():
+                for param in self.specialParams:
+                    if hasattr(chan, param):
+                        setattr(chan, param,
+                                tmpLib.channelDict.get(getattr(chan, param), None)
+                                )
+            self.channelDict.update(tmpLib.channelDict)
+            # grab library version
+            self.version = tmpLib.version
+            self.build_connectivity_graph()
+        except IOError:
+            print('No channel library found.')
+        except ValueError:
+            print('Failed to load channel library.')
 
     def update_from_file(self):
         """
@@ -186,30 +176,18 @@ class ChannelLibrary(Atom):
             if shapeFunName:
                 paramDict['shapeFun'] = getattr(PulseShapes, shapeFunName)
             self.channelDict[chName].pulseParams = paramDict
-        if 'physChan' in chParams.keys():
-            self.channelDict[chName].physChan = self.channelDict[chParams[
-                'physChan']] if chParams[
-                    'physChan'] in self.channelDict else None
-        if 'gateChan' in chParams.keys():
-            self.channelDict[chName].gateChan = self.channelDict[chParams[
-                'gateChan']] if chParams[
-                    'gateChan'] in self.channelDict else None
-        if 'trigChan' in chParams.keys():
-            self.channelDict[chName].trigChan = self.channelDict[chParams[
-                'trigChan']] if chParams[
-                    'trigChan'] in self.channelDict else None
-        if 'source' in chParams.keys():
-            self.channelDict[chName].source = self.channelDict[chParams[
-                'source']] if chParams['source'] in self.channelDict else None
-        if 'target' in chParams.keys():
-            self.channelDict[chName].target = self.channelDict[chParams[
-                'target']] if chParams['target'] in self.channelDict else None
+
+        for param in self.specialParams:
+            if param in chParams.keys():
+                setattr(self.channelDict[chName],
+                        param,
+                        self.channelDict.get(chParams[param], None)
+                        )
         # TODO: how do we follow changes to selected AWG or generator?
 
         # ignored or specially handled parameters
-        ignoreList = ['pulseParams', 'physChan', 'gateChan', 'trigChan',
-                      'source', 'target', 'AWG', 'generator', 'x__class__',
-                      'x__module__']
+        ignoreList = self.specialParams + ['pulseParams', 'AWG', 'generator',
+                     'x__class__', 'x__module__']
         for paramName in chParams:
             if paramName not in ignoreList:
                 setattr(self.channelDict[chName], paramName,

--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -39,7 +39,7 @@ class ChannelLibrary(Atom):
     connectivityG = Typed(nx.DiGraph)
     libFile = Str()
     fileWatcher = Typed(FileWatcher.LibraryFileWatcher)
-    version = Int(4)
+    version = Int(5)
 
     def __init__(self, channelDict={}, **kwargs):
         super(ChannelLibrary, self).__init__(channelDict=channelDict, **kwargs)

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -70,7 +70,7 @@ class PhysicalChannel(Channel):
     '''
     The main class for actual AWG channels.
     '''
-    AWG = Str()
+    instrument = Str() # i.e. the AWG or receiver
     translator = Str()
     generator = Str()
     samplingRate = Float(default=1.2e9)
@@ -93,7 +93,7 @@ class LogicalChannel(Channel):
 
 class PhysicalMarkerChannel(PhysicalChannel):
     '''
-    An digital output channel on an AWG.
+    A digital output channel on an AWG.
     '''
     gateBuffer = Float(0.0).tag(
         desc="How much extra time should be added onto the beginning of a gating pulse")
@@ -116,6 +116,11 @@ class PhysicalQuadratureChannel(PhysicalChannel):
             [[self.ampFactor, self.ampFactor * tan(self.phaseSkew * pi / 180)],
              [0, 1 / cos(self.phaseSkew * pi / 180)]])
 
+class ReceiverChannel(PhysicalChannel):
+    '''
+    A trigger input on a receiver.
+    '''
+    channel = Str()
 
 class LogicalMarkerChannel(LogicalChannel):
     '''

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -218,4 +218,8 @@ class Edge(LogicalChannel):
 
 
 NewLogicalChannelList = [Qubit, Edge, LogicalMarkerChannel, Measurement]
-NewPhysicalChannelList = [PhysicalMarkerChannel, PhysicalQuadratureChannel]
+NewPhysicalChannelList = [
+    PhysicalMarkerChannel,
+    PhysicalQuadratureChannel,
+    ReceiverChannel
+]

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -50,7 +50,7 @@ class Channel(Atom):
         jsonDict = self.__getstate__()
 
         #Turn objects into labels
-        for member in ["physChan", "gateChan", "trigChan", "source", "target"]:
+        for member in ["physChan", "gateChan", "trigChan", "receiverChan", "source", "target"]:
             if member in jsonDict and not isinstance(jsonDict[member], str):
                 obj = jsonDict.pop(member)
                 if obj:
@@ -169,6 +169,7 @@ class Measurement(LogicalChannel):
                                 'sigma': 1e-9})
     gateChan = Instance((str, LogicalMarkerChannel))
     trigChan = Instance((str, LogicalMarkerChannel))
+    receiverChan = Instance((str, ReceiverChannel))
 
     def __init__(self, **kwargs):
         super(Measurement, self).__init__(**kwargs)

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -250,7 +250,7 @@ def channel_delay_map(physicalWires):
 def setup_awg_channels(physicalChannels):
     translators = {}
     for chan in physicalChannels:
-        translators[chan.AWG] = import_module('QGL.drivers.' + chan.translator)
+        translators[chan.instrument] = import_module('QGL.drivers.' + chan.translator)
 
     data = {awg: translator.get_empty_channel_set()
             for awg, translator in translators.items()}
@@ -271,10 +271,10 @@ def bundle_wires(physWires, wfs):
     for chan in physWires.keys():
         _, awgChan = chan.label.split('-')
         awgChan = 'ch' + awgChan
-        awgData[chan.AWG][awgChan]['linkList'] = physWires[chan]
-        awgData[chan.AWG][awgChan]['wfLib'] = wfs[chan]
+        awgData[chan.instrument][awgChan]['linkList'] = physWires[chan]
+        awgData[chan.instrument][awgChan]['wfLib'] = wfs[chan]
         if hasattr(chan, 'correctionT'):
-            awgData[chan.AWG][awgChan]['correctionT'] = chan.correctionT
+            awgData[chan.instrument][awgChan]['correctionT'] = chan.correctionT
     return awgData
 
 

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -435,8 +435,10 @@ def compile_to_hardware(seqs,
             'points': list(range(1, 1 + num_measurements)),
             'partition': 1
         }]
-    receiver_measurements = {wire.receiverChan.label: n
-                             for wire, n in wire_measurements.items()}
+    receiver_measurements = {}
+    for wire, n in wire_measurements.items():
+        if wire.receiverChan:
+            receiver_measurements[wire.receiverChan.label] = n
     meta = {
         'instruments': files,
         'num_sequences': len(seqs),

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -381,6 +381,7 @@ def compile_to_hardware(seqs,
 
     # save number of measurements for meta info
     num_measurements = count_measurements(wireSeqs)
+    wire_measurements = count_measurements_per_wire(wireSeqs)
 
     # map logical to physical channels
     physWires = map_logical_to_physical(wireSeqs)
@@ -434,11 +435,14 @@ def compile_to_hardware(seqs,
             'points': list(range(1, 1 + num_measurements)),
             'partition': 1
         }]
+    receiver_measurements = {wire.receiverChan.label: n
+                             for wire, n in wire_measurements.items()}
     meta = {
         'instruments': files,
         'num_sequences': len(seqs),
         'num_measurements': num_measurements,
         'axis_descriptor': axis_descriptor,
+        'receivers': receiver_measurements
     }
     metafilepath = os.path.join(config.AWGDir, fileName + '-meta.json')
     with open(metafilepath, 'w') as FID:
@@ -849,8 +853,24 @@ def count_measurements(wireSeqs):
     seq_len = len(wireSeqs[list(wireSeqs)[0]])
     seq_measurements = [0 for _ in range(seq_len)]
     for ct in range(seq_len):
-        for wire, seqs in wireSeqs.items():
-            seq_measurements[ct] = max(
-                seq_measurements[ct],
-                sum(PatternUtils.contains_measurement(e) for e in seqs[ct]))
+        seq_measurements[ct] = \
+            reduce(max, count_measurements_per_wire_idx(wireSeqs, ct).values())
     return sum(seq_measurements)
+
+def count_measurements_per_wire(wireSeqs):
+    # pick an arbitrary key to determine sequence length
+    seq_len = len(wireSeqs[list(wireSeqs)[0]])
+    meas_wires = list(filter(lambda x: isinstance(x, Channels.Measurement), wireSeqs))
+    measurements = {wire: 0 for wire in meas_wires}
+    for ct in range(seq_len):
+        seq_measurements = count_measurements_per_wire_idx(wireSeqs, ct)
+        for wire in meas_wires:
+            measurements[wire] += seq_measurements[wire]
+    return measurements
+
+def count_measurements_per_wire_idx(wireSeqs, idx):
+    measurements = {
+        wire: sum(PatternUtils.contains_measurement(e) for e in seqs[idx])
+              for wire, seqs in wireSeqs.items()
+    }
+    return measurements

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -123,6 +123,8 @@ class CompileUtils(unittest.TestCase):
     def test_num_measurements(self):
         q1 = self.q1
         q2 = self.q2
+        mq1 = MEAS(q1).channel
+        mq2 = MEAS(q2).channel
         seqs = [[X(q1)*X(q2)]]
         wireSeqs = Compiler.compile_sequences(seqs)
         assert Compiler.count_measurements(wireSeqs) == 0
@@ -142,6 +144,9 @@ class CompileUtils(unittest.TestCase):
         seqs = [[MEAS(q1)*MEAS(q2), MEAS(q2)]]
         wireSeqs = Compiler.compile_sequences(seqs)
         assert Compiler.count_measurements(wireSeqs) == 2
+        wire_meas = Compiler.count_measurements_per_wire(wireSeqs)
+        assert wire_meas[mq1] == 1
+        assert wire_meas[mq2] == 2
 
         seqs = [[MEAS(q1)*MEAS(q2), MEAS(q2)],
                 [MEAS(q1)],
@@ -150,6 +155,9 @@ class CompileUtils(unittest.TestCase):
                 [X(q1)]]
         wireSeqs = Compiler.compile_sequences(seqs)
         assert Compiler.count_measurements(wireSeqs) == 5
+        wire_meas = Compiler.count_measurements_per_wire(wireSeqs)
+        assert wire_meas[mq1] == 3
+        assert wire_meas[mq2] == 4
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -382,7 +382,7 @@ class APS2Helper(AWGTestHelper):
             channelName = name + '-12'
             channel = PhysicalQuadratureChannel(label=channelName)
             channel.samplingRate = 1.2e9
-            channel.AWG = name
+            channel.instrument = name
             channel.translator = 'APS2Pattern'
             self.channels[channelName] = channel
 
@@ -390,7 +390,7 @@ class APS2Helper(AWGTestHelper):
                 channelName = "{0}-12m{1}".format(name, m)
                 channel = PhysicalMarkerChannel(label=channelName)
                 channel.samplingRate = 1.2e9
-                channel.AWG = name
+                channel.instrument = name
                 channel.translator = 'APS2Pattern'
                 self.channels[channelName] = channel
 
@@ -421,7 +421,7 @@ class TestAPS2(unittest.TestCase, APS2Helper, TestSequences):
     def test_mux_CR(self):
         #control and CR sharing the same chans
         self.channels['cr'].physChan = self.channels['q1'].physChan
-        self.channels['q1'].frequency = 100e6 
+        self.channels['q1'].frequency = 100e6
         self.channels['cr'].frequency = 200e6
         ChannelLibrary.channelLib.build_connectivity_graph()
         seqs = [CNOT_CR(self.q1, self.q2)]
@@ -449,7 +449,7 @@ class TestAPS1(unittest.TestCase, AWGTestHelper, TestSequences):
                 channelName = name + '-' + ch
                 channel = PhysicalQuadratureChannel(label=channelName)
                 channel.samplingRate = 1.2e9
-                channel.AWG = name
+                channel.instrument = name
                 channel.translator = 'APSPattern'
                 self.channels[channelName] = channel
 
@@ -457,7 +457,7 @@ class TestAPS1(unittest.TestCase, AWGTestHelper, TestSequences):
                 channelName = "{0}-{1}m1".format(name, m)
                 channel = PhysicalMarkerChannel(label=channelName)
                 channel.samplingRate = 1.2e9
-                channel.AWG = name
+                channel.instrument = name
                 channel.translator = 'APSPattern'
                 self.channels[channelName] = channel
 
@@ -561,7 +561,7 @@ class TestTek5014(unittest.TestCase, AWGTestHelper, TestSequences):
                 channelName = name + '-' + ch
                 channel = PhysicalQuadratureChannel(label=channelName)
                 channel.samplingRate = 1.2e9
-                channel.AWG = name
+                channel.instrument = name
                 channel.translator = 'TekPattern'
                 self.channels[channelName] = channel
 
@@ -569,7 +569,7 @@ class TestTek5014(unittest.TestCase, AWGTestHelper, TestSequences):
                 channelName = "{0}-{1}".format(name, m)
                 channel = PhysicalMarkerChannel(label=channelName)
                 channel.samplingRate = 1.2e9
-                channel.AWG = name
+                channel.instrument = name
                 channel.translator = 'TekPattern'
                 self.channels[channelName] = channel
 
@@ -710,13 +710,13 @@ class TestTek5014(unittest.TestCase, AWGTestHelper, TestSequences):
 # 			for ch in ['12']:
 # 				channelName = name + '-' + ch
 # 				channel = PhysicalQuadratureChannel(label=channelName)
-# 				channel.AWG = self.instruments[name]
+# 				channel.instrument = self.instruments[name]
 # 				self.channels[channelName] = channel
 
 # 			for m in ['1m1', '1m2', '2m1', '2m2']:
 # 				channelName = "{0}-{1}".format(name,m)
 # 				channel = PhysicalMarkerChannel(label=channelName)
-# 				channel.AWG = self.instruments[name]
+# 				channel.instrument = self.instruments[name]
 # 				self.channels[channelName] = channel
 
 # 		mapping = { 'digitizerTrig'	:'TEK1-1m2',


### PR DESCRIPTION
Allows one to make the measurement -> digitizer connection explicit. This allows things like counting the number of measurements for each digitizer/receiver, such that these do not have to be uniform.