### PR TITLE
Allow ControlInstructions to take a channels argument

### DIFF
--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -44,7 +44,7 @@ class Channel(Atom):
         return str(self)
 
     def __str__(self):
-        return "{0}: {1}".format(self.__class__.__name__, self.label)
+        return "{0}('{1}')".format(self.__class__.__name__, self.label)
 
     def json_encode(self):
         jsonDict = self.__getstate__()

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -599,10 +599,15 @@ def compile_sequence(seq, channels=None, edgesToCompile=None, qubitToCompile=Non
     logger.debug("Sequence before normalizing:")
     for block in normalize(flatten(seq), channels):
         logger.debug(" %s", block)
-        # labels and control flow instructions broadcast to all channels
-        if isinstance(block,
-                      (BlockLabel.BlockLabel, ControlFlow.ControlInstruction)):
+        # labels broadcast to all channels
+        if isinstance(block, BlockLabel.BlockLabel):
             for chan in channels:
+                wires[chan] += [copy(block)]
+            continue
+        # control flow broadcasts to all channels if channel attribute is None
+        if isinstance(block, ControlFlow.ControlInstruction):
+            block_channels = block.channel if block.channel else channels
+            for chan in block_channels:
                 wires[chan] += [copy(block)]
             continue
         # propagate frame change from nodes to edges

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -606,7 +606,7 @@ def compile_sequence(seq, channels=None, edgesToCompile=None, qubitToCompile=Non
             continue
         # control flow broadcasts to all channels if channel attribute is None
         if isinstance(block, ControlFlow.ControlInstruction):
-            block_channels = block.channel if block.channel else channels
+            block_channels = block.channels if block.channels else channels
             for chan in block_channels:
                 wires[chan] += [copy(block)]
             continue

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -670,7 +670,7 @@ def propagate_node_frame_to_edges(wires, chan, frameChange):
 def find_unique_channels(seq):
     channels = set()
     for step in flatten(seq):
-        if not hasattr(step, 'channel'):
+        if not hasattr(step, 'channel') or step.channel is None:
             continue
         if isinstance(step.channel, Channels.Channel):
             channels.add(step.channel)

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -79,22 +79,28 @@ def repeatall(n, seqs):
     return seqs
 
 
-def qwait(channel=None, kind="TRIG"):
+def qwait(channels=None, kind="TRIG"):
+    '''
+    Insert a WAIT or LOADCMP command on the target channels (an iterable, or None)
+    '''
     if kind == "TRIG":
-        return Wait(channel)
+        return Wait(channels)
     else:
-        return LoadCmp(channel)
+        return LoadCmp(channels)
 
 
-def qsync(channel=None):
-    return Sync(channel)
+def qsync(channels=None):
+    '''
+    Insert a SYNC command on the target channels (an iterable, or None).
+    '''
+    return Sync(channels)
 
 ## Sequencer primitives ##
 
 
 class ControlInstruction(object):
-    def __init__(self, instruction, channel=None, target=None, value=None):
-        self.channel = channel
+    def __init__(self, instruction, channels=None, target=None, value=None):
+        self.channels = channels
         self.instruction = instruction
         self.target = target  #refactor into payload field??
         self.value = value
@@ -105,7 +111,7 @@ class ControlInstruction(object):
 
     def __str__(self):
         result = self.instruction + "("
-        chan_str = str(self.channel) if self.channel else None
+        chan_str = str(self.channels) if self.channels else None
         target_str = str(self.target) if self.target else None
         value_str = str(self.value) if self.value else None
         result += ", ".join(filter(None, [chan_str, target_str, value_str]))
@@ -157,18 +163,18 @@ class Repeat(ControlInstruction):
 
 
 class Wait(ControlInstruction):
-    def __init__(self, channel=None):
-        super(Wait, self).__init__("WAIT", channel)
+    def __init__(self, channels=None):
+        super(Wait, self).__init__("WAIT", channels)
 
 
 class LoadCmp(ControlInstruction):
-    def __init__(self, channel=None):
-        super(LoadCmp, self).__init__("LOADCMP", channel)
+    def __init__(self, channels=None):
+        super(LoadCmp, self).__init__("LOADCMP", channels)
 
 
 class Sync(ControlInstruction):
-    def __init__(self, channel=None):
-        super(Sync, self).__init__("SYNC", channel)
+    def __init__(self, channels=None):
+        super(Sync, self).__init__("SYNC", channels)
 
 
 class ComparisonInstruction(ControlInstruction):

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -123,6 +123,9 @@ class ControlInstruction(object):
     def promote(self):
         return self
 
+class Store(ControlInstruction):
+    def __init__(self, target, value):
+        super(Store, self).__init__("STORE", target=target, value=value)
 
 class Goto(ControlInstruction):
     # target is a BlockLabel

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -175,8 +175,7 @@ class ComparisonInstruction(ControlInstruction):
         self.operator = operator
 
     def __str__(self):
-        labelPart = "{0}: ".format(self.label) if self.label else ""
-        return labelPart + "CMP " + self.operator + " " + str(self.mask)
+        return "CMP " + self.operator + " " + str(self.mask)
 
 
 def CmpEq(mask):

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -79,15 +79,15 @@ def repeatall(n, seqs):
     return seqs
 
 
-def qwait(kind="TRIG"):
+def qwait(channel=None, kind="TRIG"):
     if kind == "TRIG":
-        return Wait()
+        return Wait(channel)
     else:
-        return LoadCmp()
+        return LoadCmp(channel)
 
 
-def qsync():
-    return Sync()
+def qsync(channel=None):
+    return Sync(channel)
 
 ## Sequencer primitives ##
 

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -93,33 +93,28 @@ def qsync():
 
 
 class ControlInstruction(object):
-    def __init__(self, instruction, target=None, value=None):
+    def __init__(self, instruction, channel=None, target=None, value=None):
+        self.channel = channel
         self.instruction = instruction
         self.target = target  #refactor into payload field??
         self.value = value
-        self.label = None
         self.length = 0
 
     def __repr__(self):
         return self.__str__()
 
     def __str__(self):
-        labelPart = "{0}: ".format(self.label) if self.label else ""
-        result = labelPart + self.instruction
-        if self.target:
-            result += "(" + str(self.target) + ")"
-        elif self.value:
-            result += "(" + str(self.value) + ")"
+        result = self.instruction + "("
+        chan_str = str(self.channel) if self.channel else None
+        target_str = str(self.target) if self.target else None
+        value_str = str(self.value) if self.value else None
+        result += ", ".join(filter(None, [chan_str, target_str, value_str]))
+        result += ")"
         return result
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            # ignore label in equality testing
-            mydict = self.__dict__.copy()
-            otherdict = other.__dict__.copy()
-            mydict.pop('label')
-            otherdict.pop('label')
-            return mydict == otherdict
+            return self.__dict__ == other.__dict__
         return False
 
     def __ne__(self, other):
@@ -159,18 +154,18 @@ class Repeat(ControlInstruction):
 
 
 class Wait(ControlInstruction):
-    def __init__(self):
-        super(Wait, self).__init__("WAIT")
+    def __init__(self, channel=None):
+        super(Wait, self).__init__("WAIT", channel)
 
 
 class LoadCmp(ControlInstruction):
-    def __init__(self):
-        super(LoadCmp, self).__init__("LOADCMP")
+    def __init__(self, channel=None):
+        super(LoadCmp, self).__init__("LOADCMP", channel)
 
 
 class Sync(ControlInstruction):
-    def __init__(self):
-        super(Sync, self).__init__("SYNC")
+    def __init__(self, channel=None):
+        super(Sync, self).__init__("SYNC", channel)
 
 
 class ComparisonInstruction(ControlInstruction):

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -208,11 +208,11 @@ def contains_measurement(entry):
     """
     Determines if a LL entry contains a measurement
     """
-    if entry.label == "MEAS":
+    if hasattr(entry, 'label') and entry.label == "MEAS":
         return True
     elif isinstance(entry, PulseBlock):
         for p in entry.pulses.values():
-            if p.label == "MEAS":
+            if hasattr(p, 'label') and p.label == "MEAS":
                 return True
     return False
 

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -34,10 +34,10 @@ class ControlFlowTest(unittest.TestCase):
 
     def test_inline_qif(self):
         q1 = self.q1
-        seq = [X90(q1), Y(q1), qwait("CMP"), qif(0, [Id(q1)], [X(q1)]), Y(q1)]
+        seq = [X90(q1), Y(q1), qwait(kind="CMP"), qif(0, [Id(q1)], [X(q1)]), Y(q1)]
         Compiler.compile_sequence(seq)
 
-        seq = [X90(q1), Y(q1), qwait("CMP"), qif(0, [Id(q1)], [X(q1)]), Y(q1)]
+        seq = [X90(q1), Y(q1), qwait(kind="CMP"), qif(0, [Id(q1)], [X(q1)]), Y(q1)]
         seqs = [[Id(q1), Y(q1)], [X(q1), Y(q1)], seq]
         Compiler.compile_sequences(seqs)
 
@@ -83,7 +83,7 @@ class ControlFlowTest(unittest.TestCase):
 
     def test_qwait(self):
         q1 = self.q1
-        seq1 = [qwait(), qwait("CMP")]
+        seq1 = [qwait(), qwait(kind="CMP")]
         assert (isinstance(seq1[0], ControlFlow.Wait))
         assert (isinstance(seq1[1], ControlFlow.LoadCmp))
 

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -74,7 +74,7 @@ class SequenceTestCases(object):
                 chanStr = '/channels'
                 chanGroup = FID.create_group(chanStr)
                 for channel in channels:
-                    channelStr = repr(channel)
+                    channelStr = channel.label
                     FID.create_dataset('/' + chanStr + '/' + channelStr,
                                        data=waveform[channel])
 
@@ -102,12 +102,12 @@ class SequenceTestCases(object):
 
         assert (caseName in self.validWaveforms)
         validWaveform = self.validWaveforms[caseName]
-        for channelName, waveform in self.waveforms[caseName].items():
+        for channel, waveform in self.waveforms[caseName].items():
             print('Validating {0} Case {1} Channel {2}'.format(
-                self.__class__.__name__, caseName, repr(channelName)))
-            assert (repr(channelName) in validWaveform)
+                self.__class__.__name__, caseName, str(channel)))
+            assert (channel.label in validWaveform)
             np.testing.assert_allclose(waveform,
-                                       validWaveform[repr(channelName)],
+                                       validWaveform[channel.label],
                                        rtol=1e-5,
                                        atol=0)
 

--- a/tests/test_data/multi-align.h5
+++ b/tests/test_data/multi-align.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aa56cd8cbebe921303837b3f25370f0ba2ea1ba58bbc5e2e5b88976a1f61bb4
+oid sha256:9b19c526e4f8dc4982307007309320ab127a7ba6fddde3106c83dfa94202dd5d
 size 13344

--- a/tests/test_data/multi-composite.h5
+++ b/tests/test_data/multi-composite.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:decf2f8e97d46045c38d546f3dc367eb6cc60785c07dde2b95e150cf1b9cd839
+oid sha256:801a941a9e24fdf5732bae323eaaa1fe1f52ce3186b39de66c854e3fe03a9289
 size 11808

--- a/tests/test_data/multi-operators.h5
+++ b/tests/test_data/multi-operators.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c84ef386d4197706cf858dae034bfa8745a0c13ac626a6d68d995e5e0a070c27
+oid sha256:1851de1abf3dcae8678ef593274c79d3706b1dc8670bb494b2faacdea3e4af92
 size 16448

--- a/tests/test_data/single-ramsey.h5
+++ b/tests/test_data/single-ramsey.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15996bddcf230d1ac8081e7e88a02c2831ccabae2ad4b6305c75ea012af15cd2
+oid sha256:69cd0e0345520d3a963fdca86f9426de6769a9eafeadcf993bd44775830798cf
 size 126592

--- a/tests/test_data/single-repeat.h5
+++ b/tests/test_data/single-repeat.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:489082292f429f228e8c4d705c325e7e8744cb86798416fdee48d3a2120ec522
+oid sha256:cbdcb6e98cf22c76fb670bc37e599ef6c3e2e86094e61796cc980345b54e7ad8
 size 12288


### PR DESCRIPTION
And use the passed `channels` to determine where it should broadcast. The specific use case I have in mind is `Wait(q1)`, `Wait(q2)`, etc.

Also introduces a `Store` instruction that I intend to be ignored from the compiler's perspective. But, it is nice for the human.