### PR TITLE
Scheduler and CompoundGates

### DIFF
--- a/QGL/BasicSequences/CR.py
+++ b/QGL/BasicSequences/CR.py
@@ -70,9 +70,15 @@ def EchoCRLen(controlQ,
 	calRepeats : number of repetitions of readout calibrations for each 2-qubit state
 	showPlot : whether to plot (boolean)
 	"""
-    seqs = [[Id(controlQ)] + echoCR(controlQ, targetQ, length=l, phase=phase, amp=amp, riseFall=riseFall) + [Id(controlQ), MEAS(targetQ)*MEAS(controlQ)]\
-     for l in lengths]+ [[X(controlQ)] + echoCR(controlQ, targetQ, length=l, phase= phase, amp=amp, riseFall=riseFall) + [X(controlQ), MEAS(targetQ)*MEAS(controlQ)]\
-      for l in lengths] + create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
+    seqs = [[Id(controlQ),
+             echoCR(controlQ, targetQ, length=l, phase=phase, amp=amp, riseFall=riseFall),
+             Id(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for l in lengths] + \
+           [[X(controlQ),
+             echoCR(controlQ, targetQ, length=l, phase= phase, amp=amp, riseFall=riseFall),
+             X(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for l in lengths] + \
+           create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
 
     fileNames = compile_to_hardware(seqs, 'EchoCR/EchoCR',
         axis_descriptor=[
@@ -107,9 +113,15 @@ def EchoCRPhase(controlQ,
 	calRepeats : number of repetitions of readout calibrations for each 2-qubit state
 	showPlot : whether to plot (boolean)
 	"""
-    seqs = [[Id(controlQ)] + echoCR(controlQ, targetQ, length=length, phase=ph, amp=amp, riseFall=riseFall) + [X90(targetQ)*Id(controlQ), MEAS(targetQ)*MEAS(controlQ)] \
-    for ph in phases]+[[X(controlQ)] + echoCR(controlQ, targetQ, length=length, phase= ph, amp=amp, riseFall = riseFall) + [X90(targetQ)*X(controlQ), MEAS(targetQ)*MEAS(controlQ)]\
-     for ph in phases]+create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
+    seqs = [[Id(controlQ),
+             echoCR(controlQ, targetQ, length=length, phase=ph, amp=amp, riseFall=riseFall),
+             X90(targetQ)*Id(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for ph in phases] + \
+           [[X(controlQ),
+             echoCR(controlQ, targetQ, length=length, phase= ph, amp=amp, riseFall = riseFall),
+             X90(targetQ)*X(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for ph in phases] + \
+             create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
 
     axis_descriptor = [
         {
@@ -151,9 +163,15 @@ def EchoCRAmp(controlQ,
 	calRepeats : number of repetitions of readout calibrations for each 2-qubit state
 	showPlot : whether to plot (boolean)
 	"""
-    seqs = [[Id(controlQ)] + echoCR(controlQ, targetQ, length=length, phase=phase, riseFall=riseFall,amp=a) + [Id(controlQ), MEAS(targetQ)*MEAS(controlQ)]\
-     for a in amps]+ [[X(controlQ)] + echoCR(controlQ, targetQ, length=length, phase= phase, riseFall=riseFall,amp=a) + [X(controlQ), MEAS(targetQ)*MEAS(controlQ)]\
-      for a in amps] + create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
+    seqs = [[Id(controlQ),
+             echoCR(controlQ, targetQ, length=length, phase=phase, riseFall=riseFall,amp=a),
+             Id(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for a in amps] + \
+           [[X(controlQ),
+             echoCR(controlQ, targetQ, length=length, phase= phase, riseFall=riseFall,amp=a),
+             X(controlQ),
+             MEAS(targetQ)*MEAS(controlQ)] for a in amps] + \
+           create_cal_seqs((targetQ,controlQ), calRepeats, measChans=(targetQ,controlQ))
 
     axis_descriptor = [
         {

--- a/QGL/BlockLabel.py
+++ b/QGL/BlockLabel.py
@@ -22,7 +22,7 @@ class BlockLabel(object):
     def __hash__(self):
         return hash(self.label)
 
-    def promote(self):
+    def promote(self, ptype):
         return self
 
     @property

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -333,7 +333,8 @@ def compile_to_hardware(seqs,
 
     # Add gating/blanking pulses
     logger.debug("Adding blanking pulses")
-    PatternUtils.add_gate_pulses(seqs)
+    for seq in seqs:
+        PatternUtils.add_gate_pulses(seq)
 
     if not qgl2 or addQGL2SlaveTrigger:
         # Add the slave trigger
@@ -574,7 +575,7 @@ def normalize(seq, channels=None):
     with uniform channels on each PulseBlock. We inject Id's where necessary.
     '''
     # promote to PulseBlocks
-    seq = [p.promote() for p in seq]
+    seq = [p.promote(PulseBlock) for p in seq]
 
     if not channels:
         channels = find_unique_channels(seq)

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -129,7 +129,7 @@ class ControlInstruction(object):
     def __ne__(self, other):
         return not self == other
 
-    def promote(self):
+    def promote(self, ptype):
         return self
 
 class Store(ControlInstruction):

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -20,7 +20,7 @@ import hashlib, collections
 import pickle
 from copy import copy
 
-from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse
+from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse, CompoundGate
 from .PulsePrimitives import BLANK
 from . import ControlFlow
 from . import BlockLabel
@@ -76,27 +76,29 @@ def correct_mixers(wfLib, T):
         wfLib[k] = T[0, :].dot(iqWF) + 1j * T[1, :].dot(iqWF)
 
 
-def add_gate_pulses(seqs):
+def add_gate_pulses(seq):
     '''
     add gating pulses to Qubit pulses
     '''
-    for seq in seqs:
-        for ct in range(len(seq)):
-            if isinstance(seq[ct], PulseBlock):
-                pb = None
-                for chan, pulse in seq[ct].pulses.items():
-                    if has_gate(chan) and not pulse.isZero and not (
-                            chan.gateChan in seq[ct].pulses.keys()):
-                        if pb:
-                            pb *= BLANK(chan, pulse.length)
-                        else:
-                            pb = BLANK(chan, pulse.length)
-                if pb:
-                    seq[ct] *= pb
-            elif hasattr(seq[ct], 'channel'):
-                chan = seq[ct].channel
-                if has_gate(chan) and not seq[ct].isZero:
-                    seq[ct] *= BLANK(chan, seq[ct].length)
+
+    for ct in range(len(seq)):
+        if isinstance(seq[ct], CompoundGate):
+            add_gate_pulses(seq[ct].seq)
+        elif isinstance(seq[ct], PulseBlock):
+            pb = None
+            for chan, pulse in seq[ct].pulses.items():
+                if has_gate(chan) and not pulse.isZero and not (
+                        chan.gateChan in seq[ct].pulses.keys()):
+                    if pb:
+                        pb *= BLANK(chan, pulse.length)
+                    else:
+                        pb = BLANK(chan, pulse.length)
+            if pb:
+                seq[ct] *= pb
+        elif hasattr(seq[ct], 'channel'):
+            chan = seq[ct].channel
+            if has_gate(chan) and not seq[ct].isZero:
+                seq[ct] *= BLANK(chan, seq[ct].length)
 
 
 def has_gate(channel):

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -615,9 +615,10 @@ def flat_top_gaussian(chan,
     """
     A constant pulse with rising and falling gaussian shape
     """
-    return Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOn, label=label+"_rise") + \
-           Utheta(chan, length=length, amp=amp, phase=phase, shapeFun=PulseShapes.constant, label=label+"_top") + \
-           Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOff, label=label+"_fall")
+    p =  Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOn, label=label+"_rise") + \
+         Utheta(chan, length=length, amp=amp, phase=phase, shapeFun=PulseShapes.constant, label=label+"_top") + \
+         Utheta(chan, length=riseFall, amp=amp, phase=phase, shapeFun=PulseShapes.gaussOff, label=label+"_fall")
+    return p._replace(label=label)
 
 
 def echoCR(controlQ,

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -21,7 +21,7 @@ import operator
 
 from math import pi, sin, cos, acos, sqrt
 import numpy as np
-from .PulseSequencer import Pulse, TAPulse, align
+from .PulseSequencer import Pulse, TAPulse, CompoundGate, align
 from functools import wraps, reduce
 
 
@@ -651,7 +651,7 @@ def echoCR(controlQ,
                              label="echoCR_second_half")]
     if lastPi:
         seq += [X(controlQ)]
-    return seq
+    return CompoundGate(seq)
 
 
 def ZX90_CR(controlQ, targetQ, **kwargs):
@@ -673,16 +673,17 @@ def CNOT_CR(controlQ, targetQ, **kwargs):
 
     if edge.isforward(controlQ, targetQ):
         # control and target for CNOT and CR match
-        return ZX90_CR(controlQ, targetQ, **kwargs) + \
+        seq = ZX90_CR(controlQ, targetQ, **kwargs).seq + \
             [Z90m(controlQ) * X90m(targetQ)]
     else:
         # control and target for CNOT and CR are inverted
-        return [Y90(controlQ) * Y90(targetQ),
+        seq = [Y90(controlQ) * Y90(targetQ),
                 X(controlQ) * X(targetQ)] + \
-                ZX90_CR(targetQ, controlQ, **kwargs) + \
+                ZX90_CR(targetQ, controlQ, **kwargs).seq + \
                [Z90(targetQ),
                 X90(controlQ) * Y90(targetQ),
                 Y90m(controlQ) * X(targetQ)]
+    return CompoundGate(seq)
 
 def CNOT_simple(source, target, **kwargs):
     # construct (source, target) channel and pull parameters from there

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -280,6 +280,11 @@ class CompoundGate(object):
         for n in range(len(self.seq)):
             yield self.seq[n]
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return all(s1 == s2 for s1, s2 in zip(self.seq, other.seq))
+        return False
+
     def __mul__(self, other):
         if isinstance(other, CompoundGate):
             other_seq = other.seq
@@ -310,6 +315,10 @@ class CompoundGate(object):
         # FIXME, should probably iterate over self.seq to build the effective
         # channel set
         return self.seq[0].channel
+
+    def promote(self, ptype):
+        # CompoundGates cannot be promoted
+        return self
 
 def promote_type(lhs, rhs):
     '''

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -129,7 +129,7 @@ class CompositePulse(namedtuple("CompositePulse", ["label", "pulses"])):
 
     def __str__(self):
         if self.label != "":
-            return self.label
+            return '{0}({1})'.format(self.label, self.channel.label)
         else:
             return "+".join([str(p) for p in self.pulses])
 

--- a/QGL/Scheduler.py
+++ b/QGL/Scheduler.py
@@ -1,0 +1,60 @@
+
+from .Channels import Edge
+from .PulseSequencer import PulseBlock
+from .ControlFlow import Barrier, ControlInstruction
+from .PatternUtils import flatten
+from warnings import warn
+
+def schedule(seq):
+    '''
+    Takes in a "serial" sequence of operations and creates a new sequence which
+    packs those operations in a maximally concurrent fashion. The user inserts
+    `Barrier()` operations to prevent the scheduler from moving operations "earlier"
+    than the barrier.
+    '''
+
+    # dictionary of per-qubit time counters
+    counters = {}
+    out_seq = []
+
+    for instr in flatten(seq):
+        if isinstance(instr, Barrier):
+            synchronize_counters(counters, instr.chanlist)
+            continue
+        channels = get_channels(instr)
+        # find the most advanced counter in the channel set
+        idx = max(counters.get(ch, 0) for ch in channels)
+
+        if idx > len(out_seq) - 1:
+            out_seq.append(instr)
+        else:
+            out_seq[idx] *= instr
+        # advance the channel counter(s)
+        for ch in channels:
+            counters[ch] = idx + 1
+
+    return out_seq
+
+def get_channels(instr):
+    '''
+    Normalizes the various ways 'channels' can be encoded in instruction into
+    a tuple of channels
+    '''
+    if not hasattr(instr, 'channel'):
+        warn("instruction %s does not have a 'channel' property", instr)
+        return None
+    if isinstance(instr, PulseBlock):
+        return tuple(instr.channel)
+    elif isinstance(instr.channel, Edge):
+        return (instr.channel.source, instr.channel.target)
+    else:
+        return (instr.channel,)
+
+def synchronize_counters(counters, channels):
+    '''
+    Advance the counter for each channel in 'channels' to the largest count
+    in the set.
+    '''
+    max_idx = max(counters.get(ch, 0) for ch in channels)
+    for ch in channels:
+        counters[ch] = max_idx

--- a/QGL/Scheduler.py
+++ b/QGL/Scheduler.py
@@ -2,6 +2,7 @@
 from .Channels import Edge
 from .PulseSequencer import PulseBlock
 from .ControlFlow import Barrier, ControlInstruction
+from .BlockLabel import BlockLabel
 from .PatternUtils import flatten
 from warnings import warn
 
@@ -21,11 +22,15 @@ def schedule(seq):
         if isinstance(instr, Barrier):
             synchronize_counters(counters, instr.chanlist)
             continue
-        channels = get_channels(instr)
-        # find the most advanced counter in the channel set
-        idx = max(counters.get(ch, 0) for ch in channels)
+        if isinstance(instr, (ControlInstruction, BlockLabel)):
+            channels = counters.keys()
+            idx = len(out_seq)
+        else:
+            channels = get_channels(instr)
+            # find the most advanced counter in the channel set
+            idx = max(counters.get(ch, 0) for ch in channels)
 
-        if idx > len(out_seq) - 1:
+        if (idx > len(out_seq) - 1) or isinstance(out_seq[idx], ControlInstruction):
             out_seq.append(instr)
         else:
             out_seq[idx] *= instr

--- a/QGL/Scheduler.py
+++ b/QGL/Scheduler.py
@@ -17,7 +17,7 @@ def schedule(seq):
     counters = {}
     out_seq = []
 
-    for instr in flatten(seq):
+    for instr in seq:
         if isinstance(instr, Barrier):
             synchronize_counters(counters, instr.chanlist)
             continue

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -8,3 +8,4 @@ from .BasicSequences import *
 from .Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms
 from .PulseSequencePlotter import plot_pulse_files
 from .Tomography import state_tomo, process_tomo
+from .Scheduler import schedule

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,18 @@
+from QGL import *
+
+def setup_test_lib():
+    q1 = Qubit(label='q1')
+    q2 = Qubit(label='q2')
+    q3 = Qubit(label='q3')
+    q4 = Qubit(label='q4')
+
+    ChannelLibrary.channelLib.channelDict = {
+        'q1': q1,
+        'q2': q2,
+        'q3': q3,
+        'q4': q4,
+        'q1q2': Edge(label='q1q2', source=q1, target=q2),
+        'q2q3': Edge(label='q2q3', source=q2, target=q3),
+        'q3q4': Edge(label='q3q4', source=q3, target=q4)
+    }
+    ChannelLibrary.channelLib.build_connectivity_graph()

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -35,13 +35,13 @@ class CompileUtils(unittest.TestCase):
     def test_add_gate_pulses(self):
         q1 = self.q1
         seq = [X90(q1), Y90(q1)]
-        PatternUtils.add_gate_pulses([seq])
+        PatternUtils.add_gate_pulses(seq)
         assert ([self.q1gate in entry.pulses.keys() for entry in seq] ==
                 [True, True])
 
         q2 = self.q2
         seq = [X90(q1), X90(q2), X(q1) * Y(q2)]
-        PatternUtils.add_gate_pulses([seq])
+        PatternUtils.add_gate_pulses(seq)
         assert ([self.q1gate in entry.pulses.keys() for entry in seq] ==
                 [True, False, True])
         assert ([self.q2gate in entry.pulses.keys() for entry in seq] ==

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -65,17 +65,8 @@ class SchedulerTest(unittest.TestCase):
                X(q1), Y(q2)]
         result = schedule(seq)
 
-        # unroll the CNOT_CR sequence
-        cnotseq = CNOT_CR(q2, q3)
-
-        # FIXME currently fails because it schedules the 2nd X(q1) "inside" the
-        # CNOT(q2, q3)
-        # assert(result == [X(q1)*cnotseq[0],
-        #                   cnotseq[1],
-        #                   cnotseq[2],
-        #                   cnotseq[3],
-        #                   cnotseq[4],
-        #                   X(q1)*Y(q2)] )
+        assert(result == [X(q1)*CNOT_CR(q2, q3),
+                          X(q1)*Y(q2)] )
 
         seq = [CNOT_simple(q1, q2), CNOT_simple(q3, q4), X(q1), X(q2)]
         result = schedule(seq)

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -1,27 +1,15 @@
 import unittest
 
 from QGL import *
-from QGL.Scheduler import schedule
+from .helpers import setup_test_lib
 
 class SchedulerTest(unittest.TestCase):
     def setUp(self):
-        self.q1 = Qubit(label='q1')
-        self.q2 = Qubit(label='q2')
-        self.q3 = Qubit(label='q3')
-        self.q4 = Qubit(label='q4')
-        self.q1q2 = Edge(label='q1q2', source=self.q1, target=self.q2)
-        self.q2q3 = Edge(label='q2q3', source=self.q2, target=self.q3)
-        self.q3q4 = Edge(label='q3q4', source=self.q3, target=self.q4)
-
-        ChannelLibrary.channelLib.channelDict = {
-            'q1': self.q1,
-            'q2': self.q2,
-            'q3': self.q3,
-            'q1q2': self.q1q2,
-            'q2q3': self.q2q3,
-            'q3q4': self.q3q4
-        }
-        ChannelLibrary.channelLib.build_connectivity_graph()
+        setup_test_lib()
+        self.q1 = QubitFactory('q1')
+        self.q2 = QubitFactory('q2')
+        self.q3 = QubitFactory('q3')
+        self.q4 = QubitFactory('q4')
 
     def test_1q_ops(self):
         q1, q2, q3 = self.q1, self.q2, self.q3

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -100,7 +100,7 @@ class SchedulerTest(unittest.TestCase):
 
         # test that "global" control flow injects barriers
         seq = [X(q1)] + \
-              qif(1, [Y(q1),Y(q2),X90(q1)], [Z(q1),Z(q2),X90(q1)]) + \
+              cond_seq + \
               [Y90(q1),Y90(q2)]
 
         result = schedule(seq)

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -79,15 +79,23 @@ class SchedulerTest(unittest.TestCase):
         # in tensor products, i.e. we want qif(..) * qif(...) to be valid
         q1, q2, q3, q4 = self.q1, self.q2, self.q3, self.q4
 
+        cond_seq = qif(1, [Y(q1),Y(q2),X90(q1)], [Z(q1),Z(q2),X90(q1)])
         seq = [X(q1),X(q2),
                CNOT(q1,q2)] + \
-              qif(1, [Y(q1),Y(q2),X90(q1)], [Z(q1),Z(q2),X90(q1)]) + \
+              cond_seq + \
               [Y90(q1),Y90(q2)]
 
         result = schedule(seq)
+
+        # construct the scheduled conditional from the original to preserve labels
+        cond_seq_scheduled = cond_seq[:2] + \
+                             [Z(q1) * Z(q2), X90(q1)] + \
+                             cond_seq[5:7] + \
+                             [Y(q1) * Y(q2), X90(q1)] + \
+                             cond_seq[-1:]
         assert(result == [X(q1) * X(q2),
                           CNOT(q1, q2)] + \
-                         qif(1, [Y(q1)*Y(q2), X90(q1)], [Z(q1)*Z(q2), X90(q1)]) + \
+                         cond_seq_scheduled + \
                          [Y90(q1) * Y90(q2)])
 
         # test that "global" control flow injects barriers
@@ -97,5 +105,5 @@ class SchedulerTest(unittest.TestCase):
 
         result = schedule(seq)
         assert(result == [X(q1)] + \
-                         qif(1, [Y(q1)*Y(q2), X90(q1)], [Z(q1)*Z(q2), X90(q1)]) + \
+                         cond_seq_scheduled + \
                          [Y90(q1) * Y90(q2)])

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -77,4 +77,25 @@ class SchedulerTest(unittest.TestCase):
     def test_controlflow(self):
         # TODO to do this properly we need ControlInstructions to be valid operands
         # in tensor products, i.e. we want qif(..) * qif(...) to be valid
-        pass
+        q1, q2, q3, q4 = self.q1, self.q2, self.q3, self.q4
+
+        seq = [X(q1),X(q2),
+               CNOT(q1,q2)] + \
+              qif(1, [Y(q1),Y(q2),X90(q1)], [Z(q1),Z(q2),X90(q1)]) + \
+              [Y90(q1),Y90(q2)]
+
+        result = schedule(seq)
+        assert(result == [X(q1) * X(q2),
+                          CNOT(q1, q2)] + \
+                         qif(1, [Y(q1)*Y(q2), X90(q1)], [Z(q1)*Z(q2), X90(q1)]) + \
+                         [Y90(q1) * Y90(q2)])
+
+        # test that "global" control flow injects barriers
+        seq = [X(q1)] + \
+              qif(1, [Y(q1),Y(q2),X90(q1)], [Z(q1),Z(q2),X90(q1)]) + \
+              [Y90(q1),Y90(q2)]
+
+        result = schedule(seq)
+        assert(result == [X(q1)] + \
+                         qif(1, [Y(q1)*Y(q2), X90(q1)], [Z(q1)*Z(q2), X90(q1)]) + \
+                         [Y90(q1) * Y90(q2)])

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -1,0 +1,101 @@
+import unittest
+
+from QGL import *
+from QGL.Scheduler import schedule
+
+class SchedulerTest(unittest.TestCase):
+    def setUp(self):
+        self.q1 = Qubit(label='q1')
+        self.q2 = Qubit(label='q2')
+        self.q3 = Qubit(label='q3')
+        self.q4 = Qubit(label='q4')
+        self.q1q2 = Edge(label='q1q2', source=self.q1, target=self.q2)
+        self.q2q3 = Edge(label='q2q3', source=self.q2, target=self.q3)
+        self.q3q4 = Edge(label='q3q4', source=self.q3, target=self.q4)
+
+        ChannelLibrary.channelLib.channelDict = {
+            'q1': self.q1,
+            'q2': self.q2,
+            'q3': self.q3,
+            'q1q2': self.q1q2,
+            'q2q3': self.q2q3,
+            'q3q4': self.q3q4
+        }
+        ChannelLibrary.channelLib.build_connectivity_graph()
+
+    def test_1q_ops(self):
+        q1, q2, q3 = self.q1, self.q2, self.q3
+
+        # uniform fill on first time step
+        seq = [X(q1), Y(q2), Z(q3),
+               X(q1), Y(q2)]
+        result = schedule(seq)
+
+        assert(result == [X(q1)*Y(q2)*Z(q3),
+                          X(q1)*Y(q2)] )
+
+        # add an extra pulse on q1
+        seq = [X(q1), X(q1), Y(q2), Z(q3), X(q1), Y(q2)]
+        result = schedule(seq)
+
+        assert(result == [X(q1)*Y(q2)*Z(q3),
+                          X(q1)*Y(q2),
+                          X(q1)] )
+
+        # same sequence but with a Barrier
+        seq = [X(q1),
+               Barrier(q1, q2, q3),
+               X(q1), Y(q2), Z(q3),
+               X(q1), Y(q2)]
+        result = schedule(seq)
+
+        assert(result == [X(q1),
+                          X(q1)*Y(q2)*Z(q3),
+                          X(q1)*Y(q2)] )
+
+    def test_1q_composite(self):
+        q1, q2, q3 = self.q1, self.q2, self.q3
+
+        seq = [X(q1)+Y(q1), X(q2),
+               Y(q1), Y(q2)]
+        result = schedule(seq)
+
+        assert(result == [(X(q1)+Y(q1))*X(q2),
+                          Y(q1)*Y(q2)] )
+
+    def test_2q_ops(self):
+        q1, q2, q3, q4 = self.q1, self.q2, self.q3, self.q4
+
+        seq = [X(q1), CNOT_simple(q2, q3),
+               X(q1), Y(q2)]
+        result = schedule(seq)
+
+        assert(result == [X(q1)*CNOT_simple(q2, q3),
+                          X(q1)*Y(q2)] )
+
+        seq = [X(q1), CNOT_CR(q2, q3),
+               X(q1), Y(q2)]
+        result = schedule(seq)
+
+        # unroll the CNOT_CR sequence
+        cnotseq = CNOT_CR(q2, q3)
+
+        # FIXME currently fails because it schedules the 2nd X(q1) "inside" the
+        # CNOT(q2, q3)
+        # assert(result == [X(q1)*cnotseq[0],
+        #                   cnotseq[1],
+        #                   cnotseq[2],
+        #                   cnotseq[3],
+        #                   cnotseq[4],
+        #                   X(q1)*Y(q2)] )
+
+        seq = [CNOT_simple(q1, q2), CNOT_simple(q3, q4), X(q1), X(q2)]
+        result = schedule(seq)
+
+        assert(result == [CNOT_simple(q1, q2) * CNOT_simple(q3, q4),
+                          X(q1) * X(q2)] )
+
+    def test_controlflow(self):
+        # TODO to do this properly we need ControlInstructions to be valid operands
+        # in tensor products, i.e. we want qif(..) * qif(...) to be valid
+        pass

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -217,7 +217,7 @@ class TestSequences(object):
     def test_misc_seqs2(self):
         """ catch all for sequences not otherwise covered """
         self.set_awg_dir()
-        seqs = [ZX90_CR(self.q1, self.q2)]
+        seqs = [[ZX90_CR(self.q1, self.q2)]]
 
         filenames = compile_to_hardware(seqs, 'MISC2/MISC2')
         self.compare_sequences('MISC2')
@@ -225,7 +225,7 @@ class TestSequences(object):
     def test_misc_seqs3(self):
         """ catch all for sequences not otherwise covered """
         self.set_awg_dir()
-        seqs = [CNOT_CR(self.q1, self.q2)]
+        seqs = [[CNOT_CR(self.q1, self.q2)]]
 
         filenames = compile_to_hardware(seqs, 'MISC3/MISC3')
         self.compare_sequences('MISC3')
@@ -233,7 +233,7 @@ class TestSequences(object):
     def test_misc_seqs4(self):
         """ catch all for sequences not otherwise covered """
         self.set_awg_dir()
-        seqs = [CNOT_CR(self.q2, self.q1)]
+        seqs = [[CNOT_CR(self.q2, self.q1)]]
 
         filenames = compile_to_hardware(seqs, 'MISC4/MISC4')
         self.compare_sequences('MISC4')
@@ -424,7 +424,7 @@ class TestAPS2(unittest.TestCase, APS2Helper, TestSequences):
         self.channels['q1'].frequency = 100e6
         self.channels['cr'].frequency = 200e6
         ChannelLibrary.channelLib.build_connectivity_graph()
-        seqs = [CNOT_CR(self.q1, self.q2)]
+        seqs = [[CNOT_CR(self.q1, self.q2)]]
 
         filenames = compile_to_hardware(seqs, 'CNOT_CR_mux/CNOT_CR_mux')
         self.compare_sequences('CNOT_CR_mux')

--- a/tests/test_pulse_types.py
+++ b/tests/test_pulse_types.py
@@ -1,0 +1,24 @@
+import unittest
+
+from QGL import *
+from QGL.PulseSequencer import *
+from .helpers import setup_test_lib
+
+class PulseTypes(unittest.TestCase):
+    def setUp(self):
+        setup_test_lib()
+        self.q1 = QubitFactory('q1')
+        self.q2 = QubitFactory('q2')
+        self.q3 = QubitFactory('q3')
+        self.q4 = QubitFactory('q4')
+
+    def test_promotion_rules(self):
+        q1, q2, q3, q4 = self.q1, self.q2, self.q3, self.q4
+
+        assert( type(X(q1)) == Pulse )
+        assert( type(X(q1) + Y(q1)) == CompositePulse )
+        assert( type(X(q1) * X(q2)) == PulseBlock )
+        assert( type((X(q1) + Y(q1)) * X(q2)) == PulseBlock )
+
+        assert( type(CNOT(q1, q2) * X(q3)) == CompoundGate )
+        assert( type(CNOT(q1, q2) * CNOT(q3, q4)) == CompoundGate )

--- a/tests/test_pulse_types.py
+++ b/tests/test_pulse_types.py
@@ -23,4 +23,5 @@ class PulseTypes(unittest.TestCase):
         assert( type((X(q1) + Y(q1)) * X(q2)) == PulseBlock )
 
         assert( type(CNOT(q1, q2) * X(q3)) == CompoundGate )
+        assert( type(X(q3) * CNOT(q1, q2)) == CompoundGate )
         assert( type(CNOT(q1, q2) * CNOT(q3, q4)) == CompoundGate )

--- a/tests/test_pulse_types.py
+++ b/tests/test_pulse_types.py
@@ -2,11 +2,13 @@ import unittest
 
 from QGL import *
 from QGL.PulseSequencer import *
+import QGL.config
 from .helpers import setup_test_lib
 
 class PulseTypes(unittest.TestCase):
     def setUp(self):
         setup_test_lib()
+        QGL.config.cnot_implementation = 'CNOT_CR'
         self.q1 = QubitFactory('q1')
         self.q2 = QubitFactory('q2')
         self.q3 = QubitFactory('q3')


### PR DESCRIPTION
Adds a scheduler to tightly pack a serial QGL1 sequence into a parallelized sequence. The user add explicit `Barrier()`s to indicate time boundaries that the scheduler should not cross.

In the process of developing this, I ran into a fairly fundamental limitation of the current QGL implementation in that it does not support operations such as:
```python
CNOT(q1,q2) * CNOT(q3, q4)
```
At least for the `CNOT_CR` implementation we return a list of pulses, and python doesn't define multiplication between lists. Consequently, this PR also introduces a new `CompoundGate` type to the pulse hierarchy which is a thin wrapper around python lists, but which allows us to define `*` on the `CompoundGate` type. This PR introduces use of `CompoundGate`s for `echoCR`, `ZX_90`, and `CNOT_CR`. A nice benefit of this change is that these gates no longer need to be pulled outside of a sequence list.

@caryan 