### PR TITLE
Utheta, Ytheta, and Ztheta operate on rotation angles rather than amplitudes.

### DIFF
--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -74,38 +74,61 @@ def Id(channel, *args, **kwargs):
 
 # the most generic pulse is Utheta
 def Utheta(qubit,
-           amp=0,
+           angle=0,
            phase=0,
            label='Utheta',
            ignoredStrParams=[],
            **kwargs):
-    '''  A generic rotation with variable amplitude and phase. '''
+    '''
+    A generic rotation with variable angle and phase.
+    This primitive needs to convert the requested rotation angle into a Pulse
+    amplitude. If the user would like to specify a specific amplitude, he/she
+    can specify it directly via the 'amp' keyword argument.
+    '''
     params = overrideDefaults(qubit, kwargs)
-        #amp and phase are now pulse parameters rather than shape parameters
+    # amp and phase are now pulse parameters rather than shape parameters
     if "amp" in params:
-      del params["amp"]
+        del params["amp"]
     if "phase" in params:
-      del params["phase"]
+        del params["phase"]
+    # allow override of angle -> amplitude lookup if the user provides an "amp"
+    # keyword argument
+    if "amp" in kwargs:
+        amp = kwargs["amp"]
+    else:
+        # construct an angle -> amplitude lookup table
+        # TODO should this live in the Channel object instead?
+        angle2amp = {
+            pi    :  qubit.pulseParams['piAmp'],
+            -pi   : -qubit.pulseParams['piAmp'],
+            pi/2  :  qubit.pulseParams['pi2Amp'],
+            -pi/2 : -qubit.pulseParams['pi2Amp'],
+        }
+        if angle in angle2amp:
+            amp = angle2amp[angle]
+        else:
+            # linearly scale based upon the 'pi/2' amplitude
+            amp  = (angle / pi/2) * qubit.pulseParams['pi2Amp']
     return Pulse(label, qubit, params, amp, phase, 0.0, ignoredStrParams)
 
 
 # generic pulses around X, Y, and Z axes
-def Xtheta(qubit, amp=0, label='Xtheta', ignoredStrParams=None, **kwargs):
-    '''  A generic X rotation with a variable amplitude  '''
+def Xtheta(qubit, angle=0, label='Xtheta', ignoredStrParams=None, **kwargs):
+    '''  A generic X rotation with a variable rotation angle  '''
     if ignoredStrParams is None:
         ignoredStrParams = ['phase', 'frameChange']
     else:
         ignoredStrParams += ['phase', 'frameChange']
-    return Utheta(qubit, amp, 0, label, ignoredStrParams, **kwargs)
+    return Utheta(qubit, angle, 0, label, ignoredStrParams, **kwargs)
 
 
-def Ytheta(qubit, amp=0, label='Ytheta', ignoredStrParams=None, **kwargs):
-    ''' A generic Y rotation with a variable amplitude '''
+def Ytheta(qubit, angle=0, label='Ytheta', ignoredStrParams=None, **kwargs):
+    ''' A generic Y rotation with a variable rotation angle '''
     if ignoredStrParams is None:
         ignoredStrParams = ['phase', 'frameChange']
     else:
         ignoredStrParams += ['phase', 'frameChange']
-    return Utheta(qubit, amp, pi / 2, label, ignoredStrParams, **kwargs)
+    return Utheta(qubit, angle, pi/2, label, ignoredStrParams, **kwargs)
 
 
 def Ztheta(qubit,
@@ -127,7 +150,7 @@ def Ztheta(qubit,
 @_memoize
 def X90(qubit, **kwargs):
     return Xtheta(qubit,
-                  qubit.pulseParams['pi2Amp'],
+                  pi/2,
                   label="X90",
                   ignoredStrParams=['amp'],
                   **kwargs)
@@ -135,7 +158,7 @@ def X90(qubit, **kwargs):
 @_memoize
 def X90m(qubit, **kwargs):
     return Xtheta(qubit,
-                  -qubit.pulseParams['pi2Amp'],
+                  -pi/2,
                   label="X90m",
                   ignoredStrParams=['amp'],
                   **kwargs)
@@ -143,7 +166,7 @@ def X90m(qubit, **kwargs):
 @_memoize
 def Y90(qubit, **kwargs):
     return Ytheta(qubit,
-                  qubit.pulseParams['pi2Amp'],
+                  pi/2,
                   label="Y90",
                   ignoredStrParams=['amp'],
                   **kwargs)
@@ -151,7 +174,7 @@ def Y90(qubit, **kwargs):
 @_memoize
 def Y90m(qubit, **kwargs):
     return Ytheta(qubit,
-                  -qubit.pulseParams['pi2Amp'],
+                  -pi/2,
                   label="Y90m",
                   ignoredStrParams=['amp'],
                   **kwargs)
@@ -163,17 +186,17 @@ def U90(qubit, phase=0, **kwargs):
     if "label" not in kwargs:
         kwargs["label"] = "U90"
     return Utheta(qubit,
-        qubit.pulseParams['pi2Amp'],
-        phase,
-        ignoredStrParams=['amp'],
-        **kwargs)
+                  pi/2,
+                  phase,
+                  ignoredStrParams=['amp'],
+                  **kwargs)
 
 if config.pulse_primitives_lib == 'standard':
     # pi rotations formed by different choice of pulse amplitude
     @_memoize
     def X(qubit, **kwargs):
         return Xtheta(qubit,
-                      qubit.pulseParams['piAmp'],
+                      pi,
                       label="X",
                       ignoredStrParams=['amp'],
                       **kwargs)
@@ -181,7 +204,7 @@ if config.pulse_primitives_lib == 'standard':
     @_memoize
     def Xm(qubit, **kwargs):
         return Xtheta(qubit,
-                      -qubit.pulseParams['piAmp'],
+                      -pi,
                       label="Xm",
                       ignoredStrParams=['amp'],
                       **kwargs)
@@ -189,7 +212,7 @@ if config.pulse_primitives_lib == 'standard':
     @_memoize
     def Y(qubit, **kwargs):
         return Ytheta(qubit,
-                      qubit.pulseParams['piAmp'],
+                      pi,
                       label="Y",
                       ignoredStrParams=['amp'],
                       **kwargs)
@@ -197,7 +220,7 @@ if config.pulse_primitives_lib == 'standard':
     @_memoize
     def Ym(qubit, **kwargs):
         return Ytheta(qubit,
-                      -qubit.pulseParams['piAmp'],
+                      -pi,
                       label="Ym",
                       ignoredStrParams=['amp'],
                       **kwargs)
@@ -208,10 +231,10 @@ if config.pulse_primitives_lib == 'standard':
         if "label" not in kwargs:
             kwargs["label"] = "U"
         return Utheta(qubit,
-            qubit.pulseParams['piAmp'],
-            phase,
-            ignoredStrParams=['amp'],
-            **kwargs)
+                      pi,
+                      phase,
+                      ignoredStrParams=['amp'],
+                      **kwargs)
 
 elif config.pulse_primitives_lib == 'all90':
     # pi rotations formed by two pi/2 rotations
@@ -288,8 +311,7 @@ def arb_axis_drag(qubit,
         calScale = (rotAngle / 2 / pi) * sampRate / sum(gaussPulse)
 
         #Calculate the phase ramp steps to achieve the desired Z component to the rotation axis
-        phaseSteps = -2 * pi * cos(
-            polarAngle) * calScale * gaussPulse / sampRate
+        phaseSteps = -2*pi * cos(polarAngle) * calScale * gaussPulse / sampRate
 
         #Calculate Z DRAG correction to phase steps
         #beta is a conversion between XY drag scaling and Z drag scaling
@@ -689,6 +711,8 @@ def CNOT_simple(source, target, **kwargs):
     # construct (source, target) channel and pull parameters from there
     channel = ChannelLibrary.EdgeFactory(source, target)
     channel.pulseParams['piAmp'] = channel.pulseParams['amp']
+    # add "pi2Amp" too so that Utheta can construct its angle2amp lookup table
+    channel.pulseParams['pi2Amp'] = channel.pulseParams['amp'] / 2
     p = X(channel, **kwargs)
     return p._replace(label="CNOT")
 


### PR DESCRIPTION
Seems to better match user expectations about what these primitives do.

The angle -> amplitude conversion is done in a lookup table constructed inside
Utheta. This allows usage like:
    Xtheta(q1, angle=pi/4)

The user can force the choice of a particular pulse amplitude by providing the
'amp' keyword argument. e.g.
   Xtheta(q1, amp=0.1)

will stuff function like it used to. This preserved backwards compatibility with
existing code.