### PR TITLE
Add marker factory for unattached markers.

### DIFF
--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -212,6 +212,7 @@ class ChannelLibrary(Atom):
             instr_dict  = tmpLib['instruments']
             qubit_dict  = tmpLib['qubits']
             filter_dict = tmpLib['filters']
+            trigger_dict = tmpLib['markers']
             master_awgs = []
 
             # Construct the channel library
@@ -378,19 +379,19 @@ class ChannelLibrary(Atom):
                     channel_dict[params["label"]] = params
                     channel_dict[name]["gate_chan"] = params["label"]
 
-                if "triggers" in qubit.keys():
-                    for trig_name, trigger in qubit["triggers"].items():
-                        phys_instr, phys_marker = trigger.split()
-                        params = {}
-                        params["label"]      = trig_name
-                        params["phys_chan"]   = phys_instr + "-" + phys_marker
-                        if params["phys_chan"] in marker_lens.keys():
-                            length = marker_lens[params["phys_chan"]]
-                        else:
-                            length = 1e-7
-                        params["__module__"] = "QGL.Channels"
-                        params["__class__"]  = "LogicalMarkerChannel"
-                        channel_dict[params["label"]] = params
+
+            for trig_name, trigger in trigger_dict.items():
+                phys_instr, phys_marker = trigger.split()
+                params = {}
+                params["label"]      = trig_name
+                params["phys_chan"]   = phys_instr + "-" + phys_marker
+                if params["phys_chan"] in marker_lens.keys():
+                    length = marker_lens[params["phys_chan"]]
+                else:
+                    length = 1e-7
+                params["__module__"] = "QGL.Channels"
+                params["__class__"]  = "LogicalMarkerChannel"
+                channel_dict[params["label"]] = params
 
             # for k, c in channel_dict.items():
             #     print("Channel {: <30} phys_chan {: <30} class {: <30} instr {: <30}".format(k, c["phys_chan"] if "phys_chan" in c else "None", c["__class__"] if "__class__" in c else "None", c["instrument"] if "instrument" in c else "None"))

--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -291,12 +291,12 @@ class ChannelLibrary(Atom):
 
             for name, filt in filter_dict.items():
                 if "StreamSelector" in filt["type"]:
-                    params = {k: v for k,v in filt.items() if k in Channels.receiver_channel.__atom_members__.keys()}
+                    params = {k: v for k,v in filt.items() if k in Channels.ReceiverChannel.__atom_members__.keys()}
                     params["label"]      = "RecvChan-" + name # instr_dict[filt["instrument"]]["name"] + "-" + name
                     params["channel"]    = str(params["channel"]) # Convert to a string
                     params["instrument"] = filt["source"]
                     params["__module__"] = "QGL.Channels"
-                    params["__class__"]  = "receiver_channel"
+                    params["__class__"]  = "ReceiverChannel"
                     if "source" not in filt.keys():
                         raise ValueError("No instrument (source) specified for Stream Selector")
                     if filt["source"] not in instr_dict.keys() and filt["source"] not in channel_dict.keys():

--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -293,7 +293,7 @@ class ChannelLibrary(Atom):
                 if "StreamSelector" in filt["type"]:
                     params = {k: v for k,v in filt.items() if k in Channels.receiver_channel.__atom_members__.keys()}
                     params["label"]      = "RecvChan-" + name # instr_dict[filt["instrument"]]["name"] + "-" + name
-                    params["channel"]    = params["channel"] # Convert to a string
+                    params["channel"]    = str(params["channel"]) # Convert to a string
                     params["instrument"] = filt["source"]
                     params["__module__"] = "QGL.Channels"
                     params["__class__"]  = "receiver_channel"

--- a/QGL/ChannelLibrary.py
+++ b/QGL/ChannelLibrary.py
@@ -378,6 +378,20 @@ class ChannelLibrary(Atom):
                     channel_dict[params["label"]] = params
                     channel_dict[name]["gate_chan"] = params["label"]
 
+                if "triggers" in qubit.keys():
+                    for trig_name, trigger in qubit["triggers"].items():
+                        phys_instr, phys_marker = trigger.split()
+                        params = {}
+                        params["label"]      = trig_name
+                        params["phys_chan"]   = phys_instr + "-" + phys_marker
+                        if params["phys_chan"] in marker_lens.keys():
+                            length = marker_lens[params["phys_chan"]]
+                        else:
+                            length = 1e-7
+                        params["__module__"] = "QGL.Channels"
+                        params["__class__"]  = "LogicalMarkerChannel"
+                        channel_dict[params["label"]] = params
+
             # for k, c in channel_dict.items():
             #     print("Channel {: <30} phys_chan {: <30} class {: <30} instr {: <30}".format(k, c["phys_chan"] if "phys_chan" in c else "None", c["__class__"] if "__class__" in c else "None", c["instrument"] if "instrument" in c else "None"))
 
@@ -438,6 +452,13 @@ class ChannelLibrary(Atom):
                     newLabel = "{0}-{1}".format(newName, awgChannel)
                     print("Changing {0} to {1}".format(chName, newLabel))
                     self.physicalChannelManager.name_changed(chName, newLabel)
+
+def MarkerFactory(label, **kwargs):
+    if channelLib and label in channelLib and isinstance(channelLib[label],
+                                                        Channels.LogicalMarkerChannel):
+        return channelLib[label]
+    else:
+        raise ValueError("Marker channel {} not found in channel library.".format(label))
 
 def QubitFactory(label, **kwargs):
     ''' Return a saved qubit channel or create a new one. '''

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -120,7 +120,7 @@ class receiver_channel(PhysicalChannel):
     '''
     A trigger input on a receiver.
     '''
-    channel = Int()
+    channel = Str()
 
 class LogicalMarkerChannel(LogicalChannel):
     '''

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -116,7 +116,7 @@ class PhysicalQuadratureChannel(PhysicalChannel):
             [[self.amp_factor, self.amp_factor * tan(self.phase_skew * pi / 180)],
              [0, 1 / cos(self.phase_skew * pi / 180)]])
 
-class receiver_channel(PhysicalChannel):
+class ReceiverChannel(PhysicalChannel):
     '''
     A trigger input on a receiver.
     '''
@@ -169,7 +169,7 @@ class Measurement(LogicalChannel):
                                 'sigma': 1e-9})
     gate_chan = Instance((str, LogicalMarkerChannel))
     trig_chan = Instance((str, LogicalMarkerChannel))
-    receiver_chan = Instance((str, receiver_channel))
+    receiver_chan = Instance((str, ReceiverChannel))
 
     def __init__(self, **kwargs):
         super(Measurement, self).__init__(**kwargs)
@@ -222,5 +222,5 @@ NewLogicalChannelList = [Qubit, Edge, LogicalMarkerChannel, Measurement]
 NewPhysicalChannelList = [
     PhysicalMarkerChannel,
     PhysicalQuadratureChannel,
-    receiver_channel
+    ReceiverChannel
 ]

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -774,7 +774,9 @@ def MeasEcho(qM, qD, delay, piShift=None, phase=0):
     measEcho.label = 'MEAS'  #to generate the digitizer trigger
     return measEcho
 
-
 # Gating/blanking pulse primitives
 def BLANK(chan, length):
     return TAPulse("BLANK", chan.gate_chan, length, 1, 0, 0)
+
+def TRIG(marker_chan, length):
+    return TAPulse("TRIG", marker_chan, length, 1.0, 0., 0.)

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -1,5 +1,5 @@
 from .Channels import Qubit, Measurement, Edge
-from .ChannelLibrary import QubitFactory, MeasFactory, EdgeFactory
+from .ChannelLibrary import QubitFactory, MeasFactory, EdgeFactory, MarkerFactory
 from .PulsePrimitives import *
 from .Compiler import compile_to_hardware, set_log_level
 from .PulseSequencer import align


### PR DESCRIPTION
Possible fix to #121 

Adds a new trigger pulse type for adding markers on the digital outputs, along with a MarkerFactory and a way to specify what channels are involved in the YAML.

In the YAML you can now do:
```yaml
qubits:
  #qubit definitions
markers:
  my_trigger: BBNAPS1 12m1
```

And then in your QGL code do:
``` python
my_trigger_chan = MarkerFactory("my_trigger")
seq = [[X90(q), MEAS(q) * TRIG(my_trigger_chan)]]
```

Thoughts?
