### PR TITLE
Remove slider for plot_pulse_files for sequences of unit length

### DIFF
--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -134,16 +134,18 @@ def plot_pulse_files(metafile, time=False):
         code=code_template.render(
             lineNames=[l.replace("-", "_") for l in lineNames]))
 
-    slider = Slider(start=1,
-                    end=num_seqs,
-                    value=1,
-                    step=1,
-                    title="Sequence",
-                    callback=callback)
+    if num_seqs > 1:
+        slider = Slider(start=1,
+                        end=num_seqs,
+                        value=1,
+                        step=1,
+                        title="Sequence",
+                        callback=callback)
 
-    layout = column(slider, plot)
-
-    show(layout)
+        layout = column(slider, plot)
+        show(layout)
+    else:
+        show(plot)
 
 
 def extract_waveforms(dataDict, fileNames, nameDecorator='', time=False):


### PR DESCRIPTION
in order to satisfy newer bokeh versions (roughly > 0.12.8). @dieris could you test this out for me?

I think the newer bokeh versions are actually using binary transport instead of JSON to go from python->JS, so things appear snappier. 