### PR TITLE
Fix/bokeh column source

### DIFF
--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -30,7 +30,7 @@ import numpy as np
 import warnings
 from . import config
 
-def output_notebook(local=True, suppress_warnings=True):
+def output_notebook(local=True, suppress_warnings=False):
     if suppress_warnings:
         warnings.simplefilter("ignore", BokehUserWarning)
     if local:

--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -286,37 +286,3 @@ def plot_pulse_files_compare(metafile1, metafile2, time=False):
         show(layout)
     else:
         show(plot)
-    # js_sources = data
-    # for ct, k in enumerate(line_names1 + line_names2):
-    #     k_ = k.replace("-", "_")
-    #     line = plot.line(dataDict[k_ + "_x_1"],
-    #                      dataDict[k_ + "_y_1"],
-    #                      color=colours[ct % len(colours)],
-    #                      line_width=2,
-    #                      legend=k)
-    #     js_sources[k_] = line.data_source
-
-    # code_template = Template("""
-    #     var seq_num = cb_obj.get('value');
-    #     //console.log(seq_num)
-    #     var all_data = all_data.get('data');
-    #     {% for line in line_names %}
-    #     {{line}}.set('data', {'x':all_data['{{line}}_x_'.concat(seq_num.toString())], 'y':all_data['{{line}}_y_'.concat(seq_num.toString())]} );
-    #     {% endfor %}
-    # """)
-
-    # callback = CustomJS(
-    #     args=js_sources,
-    #     code=code_template.render(
-    #         line_names=[l.replace("-", "_") for l in line_names1 + line_names2]))
-
-    # slider = Slider(start=1,
-    #                 end=num_seqs,
-    #                 value=1,
-    #                 step=1,
-    #                 title="Sequence",
-    #                 callback=callback)
-
-    # layout = column(slider, plot)
-
-    # show(layout)

--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -89,13 +89,11 @@ def plot_pulse_files(metafile, time=False):
             for file in el.values():
                 fileNames.append(file)
 
-    dataDict = {}
-    lineNames, num_seqs = extract_waveforms(dataDict, fileNames, time=time)
-
+    line_names, num_seqs, data_dicts = extract_waveforms(fileNames, time=time)
     localname = os.path.split(fileNames[0])[1]
     sequencename = localname.split('-')[0]
 
-    all_data = ColumnDataSource(data=dataDict)
+    data = {line_name: ColumnDataSource(data=dat) for line_name,dat in data_dicts.items()}
     plot = Figure(title=sequencename, plot_width=1000)
     plot.background_fill_color = config.plotBackground
     if config.gridColor:
@@ -108,31 +106,37 @@ def plot_pulse_files(metafile, time=False):
         "#a65628", "#f781bf", "#999999"
     ]
 
-    js_sources = {}
-    js_sources["all_data"] = all_data
-    for ct, k in enumerate(lineNames):
+    js_sources = data
+    for ct, k in enumerate(line_names):
         k_ = k.replace("-", "_")
-        line = plot.line(dataDict[k_ + "_x_1"],
-                         dataDict[k_ + "_y_1"],
+        line = plot.line(data_dicts[k + "_1"]["x"],
+                         data_dicts[k + "_1"]["y"],
                          color=colours[ct % len(colours)],
                          line_width=2,
-                         legend=k)
+                         legend=k.replace("_", "-"))
         js_sources[k_] = line.data_source
 
     code_template = Template("""
-        var seq_num = cb_obj.get('value');
-        console.log(seq_num)
-        var all_data = all_data.get('data');
-        {% for line in lineNames %}
-        {{line}}.set('data', {'x':all_data['{{line}}_x_'.concat(seq_num.toString())], 'y':all_data['{{line}}_y_'.concat(seq_num.toString())]} );
+        var seq_num = cb_obj.getv('value');
+        // console.log(seq_num);
+        var all_data = {
+            {% for trace in trace_names %}
+                '{{trace}}': {{trace}}.getv('data'),
+            {% endfor %}
+        };
+        {% for line in line_names %}
+        {{line}}['data'] = {'x': (all_data['{{line}}_'.concat(seq_num.toString())])['x'],
+                              'y': (all_data['{{line}}_'.concat(seq_num.toString())])['y']};
         {% endfor %}
-        console.log("Got here!")
     """)
+    rendered = code_template.render(
+            line_names=line_names,
+            trace_names=list(data.keys())[:-len(line_names)]
+            )
 
     callback = CustomJS(
-        args=js_sources,
-        code=code_template.render(
-            lineNames=[l.replace("-", "_") for l in lineNames]))
+        args=dict(**js_sources),
+        code=rendered)
 
     if num_seqs > 1:
         slider = Slider(start=1,
@@ -148,8 +152,9 @@ def plot_pulse_files(metafile, time=False):
         show(plot)
 
 
-def extract_waveforms(dataDict, fileNames, nameDecorator='', time=False):
-    lineNames = []
+def extract_waveforms(fileNames, nameDecorator='', time=False):
+    line_names = []
+    data_dicts = {}
     num_seqs = 0
     for fileName in sorted(fileNames):
 
@@ -167,41 +172,64 @@ def extract_waveforms(dataDict, fileNames, nameDecorator='', time=False):
             if all_zero_seqs(seqs):
                 continue
             num_seqs = max(num_seqs, len(seqs))
-            lineNames.append(AWGName + nameDecorator + '-' + k)
-            k_ = lineNames[-1].replace("-", "_")
+            line_names.append(AWGName + nameDecorator + '_' + k)
+            k_ = line_names[-1].replace("-", "_")
             for ct, seq in enumerate(seqs):
+                data_dicts[k_ + "_{:d}".format(ct + 1)] = {}
+
                 # Convert from time amplitude pairs to x,y lines with points at start and beginnning to prevent interpolation
-                dataDict[k_ + "_x_{:d}".format(ct + 1)] = sample_time * np.tile(
+                data_dicts[k_ + "_{:d}".format(ct + 1)]["x"] = sample_time * np.tile(
                     np.cumsum([0] + [_[0] for _ in seq]),
                     (2, 1)).flatten(order="F")[1:-1]
-                dataDict[k_ + "_y_{:d}".format(ct + 1)] = np.tile(
+
+                data_dicts[k_ + "_{:d}".format(ct + 1)]["y"] = np.tile(
                     [_[1] for _ in seq],
-                    (2, 1)).flatten(order="F") + 2 * (len(lineNames) - 1)
-    return lineNames, num_seqs
+                    (2, 1)).flatten(order="F") + 2 * (len(line_names) - 1)
+    return line_names, num_seqs, data_dicts
 
 
-def plot_pulse_files_compare(fileNames1, fileNames2):
+def plot_pulse_files_compare(metafile1, metafile2, time=False):
     '''
     plot_pulse_files_compare(fileNames1, fileNames2)
 
     Helper function to plot a list of AWG files. A JS slider allows choice of sequence number.
     '''
     #If we only go one filename turn it into a list
-    if isinstance(fileNames1, str):
-        fileNames1 = [fileNames1]
-    if isinstance(fileNames2, str):
-        fileNames2 = [fileNames2]
+    fileNames1 = []
+    fileNames2 = []
 
-    dataDict = {}
+    with open(metafile1, 'r') as FID:
+        meta_info = json.load(FID)
+    
+    for el in meta_info["instruments"].values():
+        # Accomodate seq_file per instrument and per channel
+        if isinstance(el, str):
+            fileNames1.append(el)
+        elif isinstance(el, dict):
+            for file in el.values():
+                fileNames1.append(file)
 
-    lineNames1, num_seqs1 = extract_waveforms(dataDict, fileNames1, 'A')
-    lineNames2, num_seqs2 = extract_waveforms(dataDict, fileNames2, 'B')
+    with open(metafile2, 'r') as FID:
+        meta_info = json.load(FID)
+    
+    for el in meta_info["instruments"].values():
+        # Accomodate seq_file per instrument and per channel
+        if isinstance(el, str):
+            fileNames2.append(el)
+        elif isinstance(el, dict):
+            for file in el.values():
+                fileNames2.append(file)
+
+    line_names1, num_seqs1, data_dicts1 = extract_waveforms(fileNames1, 'A', time=time)
+    line_names2, num_seqs2, data_dicts2 = extract_waveforms(fileNames2, 'B', time=time)
     num_seqs = max(num_seqs1, num_seqs2)
+    data_dicts1.update(data_dicts2)
+    line_names = line_names1 + line_names2
 
     localname = os.path.split(fileNames1[0])[1]
     sequencename = localname.split('-')[0]
 
-    all_data = ColumnDataSource(data=dataDict)
+    data = {line_name: ColumnDataSource(data=dat) for line_name,dat in data_dicts1.items()}
     plot = Figure(title=sequencename, plot_width=1000)
     plot.background_fill_color = config.plotBackground
     if config.gridColor:
@@ -214,39 +242,81 @@ def plot_pulse_files_compare(fileNames1, fileNames2):
         "#a65628", "#f781bf", "#999999"
     ]
 
-    js_sources = {}
-    js_sources["all_data"] = all_data
-    for ct, k in enumerate(lineNames1 + lineNames2):
+    js_sources = data
+    for ct, k in enumerate(line_names):
         k_ = k.replace("-", "_")
-        line = plot.line(dataDict[k_ + "_x_1"],
-                         dataDict[k_ + "_y_1"],
+        line = plot.line(data_dicts1[k + "_1"]["x"],
+                         data_dicts1[k + "_1"]["y"],
                          color=colours[ct % len(colours)],
                          line_width=2,
-                         legend=k)
+                         legend=k.replace("_", "-"))
         js_sources[k_] = line.data_source
 
     code_template = Template("""
-        var seq_num = cb_obj.get('value');
-        console.log(seq_num)
-        var all_data = all_data.get('data');
-        {% for line in lineNames %}
-        {{line}}.set('data', {'x':all_data['{{line}}_x_'.concat(seq_num.toString())], 'y':all_data['{{line}}_y_'.concat(seq_num.toString())]} );
+        var seq_num = cb_obj.getv('value');
+        // console.log(seq_num);
+        var all_data = {
+            {% for trace in trace_names %}
+                '{{trace}}': {{trace}}.getv('data'),
+            {% endfor %}
+        };
+        {% for line in line_names %}
+        {{line}}['data'] = {'x': (all_data['{{line}}_'.concat(seq_num.toString())])['x'],
+                              'y': (all_data['{{line}}_'.concat(seq_num.toString())])['y']};
         {% endfor %}
-        console.log("Got here!")
     """)
+    rendered = code_template.render(
+            line_names=line_names,
+            trace_names=list(data.keys())[:-len(line_names)]
+            )
 
     callback = CustomJS(
-        args=js_sources,
-        code=code_template.render(
-            lineNames=[l.replace("-", "_") for l in lineNames1 + lineNames2]))
+        args=dict(**js_sources),
+        code=rendered)
 
-    slider = Slider(start=1,
-                    end=num_seqs,
-                    value=1,
-                    step=1,
-                    title="Sequence",
-                    callback=callback)
+    if num_seqs > 1:
+        slider = Slider(start=1,
+                        end=num_seqs,
+                        value=1,
+                        step=1,
+                        title="Sequence",
+                        callback=callback)
 
-    layout = column(slider, plot)
+        layout = column(slider, plot)
+        show(layout)
+    else:
+        show(plot)
+    # js_sources = data
+    # for ct, k in enumerate(line_names1 + line_names2):
+    #     k_ = k.replace("-", "_")
+    #     line = plot.line(dataDict[k_ + "_x_1"],
+    #                      dataDict[k_ + "_y_1"],
+    #                      color=colours[ct % len(colours)],
+    #                      line_width=2,
+    #                      legend=k)
+    #     js_sources[k_] = line.data_source
 
-    show(layout)
+    # code_template = Template("""
+    #     var seq_num = cb_obj.get('value');
+    #     //console.log(seq_num)
+    #     var all_data = all_data.get('data');
+    #     {% for line in line_names %}
+    #     {{line}}.set('data', {'x':all_data['{{line}}_x_'.concat(seq_num.toString())], 'y':all_data['{{line}}_y_'.concat(seq_num.toString())]} );
+    #     {% endfor %}
+    # """)
+
+    # callback = CustomJS(
+    #     args=js_sources,
+    #     code=code_template.render(
+    #         line_names=[l.replace("-", "_") for l in line_names1 + line_names2]))
+
+    # slider = Slider(start=1,
+    #                 end=num_seqs,
+    #                 value=1,
+    #                 step=1,
+    #                 title="Sequence",
+    #                 callback=callback)
+
+    # layout = column(slider, plot)
+
+    # show(layout)

--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -172,7 +172,7 @@ def extract_waveforms(fileNames, nameDecorator='', time=False):
             if all_zero_seqs(seqs):
                 continue
             num_seqs = max(num_seqs, len(seqs))
-            line_names.append(AWGName + nameDecorator + '_' + k)
+            line_names.append((AWGName + nameDecorator + '_' + k).replace("-","_")) 
             k_ = line_names[-1].replace("-", "_")
             for ct, seq in enumerate(seqs):
                 data_dicts[k_ + "_{:d}".format(ct + 1)] = {}
@@ -199,9 +199,9 @@ def plot_pulse_files_compare(metafile1, metafile2, time=False):
     fileNames2 = []
 
     with open(metafile1, 'r') as FID:
-        meta_info = json.load(FID)
+        meta_info1 = json.load(FID)
     
-    for el in meta_info["instruments"].values():
+    for el in meta_info1["instruments"].values():
         # Accomodate seq_file per instrument and per channel
         if isinstance(el, str):
             fileNames1.append(el)
@@ -210,9 +210,9 @@ def plot_pulse_files_compare(metafile1, metafile2, time=False):
                 fileNames1.append(file)
 
     with open(metafile2, 'r') as FID:
-        meta_info = json.load(FID)
+        meta_info2 = json.load(FID)
     
-    for el in meta_info["instruments"].values():
+    for el in meta_info2["instruments"].values():
         # Accomodate seq_file per instrument and per channel
         if isinstance(el, str):
             fileNames2.append(el)

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -6,6 +6,6 @@ from .PulseSequencer import align
 from .ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync, Barrier
 from .BasicSequences import *
 from .Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms
-from .PulseSequencePlotter import plot_pulse_files, plot_pulse_files_compare
+from .PulseSequencePlotter import plot_pulse_files
 from .Tomography import state_tomo, process_tomo
 from .Scheduler import schedule

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -6,6 +6,6 @@ from .PulseSequencer import align
 from .ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync, Barrier
 from .BasicSequences import *
 from .Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms
-from .PulseSequencePlotter import plot_pulse_files
+from .PulseSequencePlotter import plot_pulse_files, plot_pulse_files_compare
 from .Tomography import state_tomo, process_tomo
 from .Scheduler import schedule


### PR DESCRIPTION
Bokeh claims that ColumnDataSources cannot have columns with different lengths. Mysteriously, plotting of waveforms still worked for some people on some computers with some versions of bokeh. At any rate, we were using deprecated bokeh API commands, and needed a refresh anyways. Each sequence and channel get their own ColumnDataSource now.

@matthewware @dieris @gribeill could you try this out?