### PR TITLE
Adds a minimal config for QGL-demo

### DIFF
--- a/doc/QGL-demo.ipynb
+++ b/doc/QGL-demo.ipynb
@@ -38,10 +38,10 @@
     "# By default, we look for the BBN_MEAS_FILE environment variable for the location of the\n",
     "# YAML configuration. Calling ChannelLibrary with no arguments will load the file from\n",
     "# that location.\n",
-    "cl = ChannelLibrary()\n",
+    "#cl = ChannelLibrary()\n",
     "\n",
     "# Altneratively you can specify the desired configuration file location.\n",
-    "# cl = ChannelLibrary(library_file=\"/path/to/measure.yaml\")"
+    "cl = ChannelLibrary(library_file=\"./config/measure.yml\")"
    ]
   },
   {

--- a/doc/config/filters.yml
+++ b/doc/config/filters.yml
@@ -1,0 +1,4 @@
+q1-RawSS:
+  type: X6StreamSelector
+  source: X6-1
+  channel: '1'

--- a/doc/config/instruments.yml
+++ b/doc/config/instruments.yml
@@ -1,0 +1,18 @@
+BBNAPS1:
+  type: APS2
+  tx_channels:
+    '12':
+  markers:
+    12m1:
+      delay: -5.0e-08
+
+BBNAPS2:
+  type: APS2
+  tx_channels:
+    '12':
+
+X6-1:
+  type: X6
+  rx_channels:
+    '1':
+    '2':

--- a/doc/config/measure.yml
+++ b/doc/config/measure.yml
@@ -1,0 +1,16 @@
+# Minimal QGL configuration for QGL-demo notebook
+# Imports can be made using the !include keyword. e.g.
+# instruments: !include instruments.yml
+config:
+  AWGDir: "./awg/"
+qubits:
+  q1:
+    measure:
+      AWG: BBNAPS1 12
+      trigger: BBNAPS1 12m1
+      receiver: q1-RawSS
+    control:
+      AWG: BBNAPS2 12
+
+instruments: !include instruments.yml
+filters: !include filters.yml


### PR DESCRIPTION
The QGL-demo will not run without a set of config files. 

This PR adds a minimal set of configs in `doc/config` which will allow the demo to run. The config files are not meant to document the config file format but rather allow someone to run the demo out of the box.

The python notebook has also been modified to point directly to these config files.