### PR TITLE
Add TDM to metafile info

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -366,7 +366,7 @@ def compile_to_hardware(seqs,
     num_measurements = count_measurements(wireSeqs)
     wire_measurements = count_measurements_per_wire(wireSeqs)
 
-    # map logical to physical channels, physWires is a list of 
+    # map logical to physical channels, physWires is a list of
     # PhysicalQuadratureChannels and PhysicalMarkerChannels
     # for the APS, the naming convention is:
     # ASPName-12, or APSName-12m1
@@ -391,7 +391,7 @@ def compile_to_hardware(seqs,
             old_wire_names[wire] = wire.label
             old_wire_instrs[wire] = wire.instrument
             wire.instrument = wire.label
-            wire.label = chan_name 
+            wire.label = chan_name
             files[inst_name] = {}
 
     # construct channel delay map
@@ -431,7 +431,10 @@ def compile_to_hardware(seqs,
                 files[label_to_inst[awgName]][label_to_chan[awgName]] = fullFileName
         else:
             files[awgName] = fullFileName
-
+    # add TDM sequence, if any
+    for tdm in config.tdm_list:
+        files[tdm] = os.path.normpath(os.path.join(
+        config.AWGDir, str.replace(fileName, 'aps', 'tdm') + '-' + next(iter(awgData)) + suffix + '.h5'))
     # create meta output
     if not axis_descriptor:
         axis_descriptor = [{

--- a/QGL/config.py
+++ b/QGL/config.py
@@ -22,7 +22,7 @@ pulse_primitives_lib = "standard"
 cnot_implementation  = "CNOT_simple"
 
 # used to add the tdm sequence in the metafile
-tdm_list = None
+tdm_list = []
 
 class LoaderMeta(type):
     def __new__(metacls, __name__, __bases__, __dict__):

--- a/QGL/config.py
+++ b/QGL/config.py
@@ -21,6 +21,9 @@ pulse_primitives_lib = "standard"
 # CNOT in your gate set, e.g. CNOT_simple or CNOT_CR)
 cnot_implementation  = "CNOT_simple"
 
+# used to add the tdm sequence in the metafile
+tdm_list = None
+
 class LoaderMeta(type):
     def __new__(metacls, __name__, __bases__, __dict__):
         """Add include constructer to class."""
@@ -67,7 +70,7 @@ def find_meas_file():
     raise Exception("Could not find the measurement file in the environment variables or the auspex globals.")
 
 def load_config(filename=None):
-    global meas_file, AWGDir, plotBackground, gridColor, pulse_primitives_lib, cnot_implementation
+    global meas_file, AWGDir, plotBackground, gridColor, pulse_primitives_lib, cnot_implementation, tdm_list
 
     if filename:
         meas_file = filename
@@ -93,5 +96,6 @@ def load_config(filename=None):
     gridColor            = cfg['config'].get('GridColor', None)
     pulse_primitives_lib = cfg['config'].get('PulsePrimitivesLibrary', 'standard')
     cnot_implementation  = cfg['config'].get('cnot_implementation', 'CNOT_simple')
+    tdm_list = [k for (k, v) in cfg['instruments'].items() if v['type'] == 'TDM']
 
     return meas_file

--- a/QGL/config.py
+++ b/QGL/config.py
@@ -12,7 +12,7 @@ meas_file            = None
 
 # plotting options
 plotBackground       = '#EAEAF2'
-gridColor            = None
+gridColor            = []
 
 # select pulse library (standard or all90)
 pulse_primitives_lib = "standard"
@@ -96,6 +96,8 @@ def load_config(filename=None):
     gridColor            = cfg['config'].get('GridColor', None)
     pulse_primitives_lib = cfg['config'].get('PulsePrimitivesLibrary', 'standard')
     cnot_implementation  = cfg['config'].get('cnot_implementation', 'CNOT_simple')
-    tdm_list = [k for (k, v) in cfg['instruments'].items() if v['type'] == 'TDM']
+
+    if 'instruments' in cfg:
+        tdm_list = [k for (k, v) in cfg['instruments'].items() if (v['type'] == 'TDM' and v['enabled'] == True)]
 
     return meas_file

--- a/QGL/config.py
+++ b/QGL/config.py
@@ -12,7 +12,7 @@ meas_file            = None
 
 # plotting options
 plotBackground       = '#EAEAF2'
-gridColor            = []
+gridColor            = None
 
 # select pulse library (standard or all90)
 pulse_primitives_lib = "standard"

--- a/QGL/n.py
+++ b/QGL/n.py
@@ -69,10 +69,10 @@ seq = [
 # same sequence twice can FAIL (or give weird results).
 # So copy the input sequence each time we use it...
 
-aps_metafile = compile_to_hardware([copy.copy(seq)], '/tmp/aps')
+aps_metafile = compile_to_hardware([copy.copy(seq)], 'tmp/aps')
 aps_metadata = json.loads(open(aps_metafile).read())
 
-tdm_metafile = compile_to_hardware([copy.copy(seq)], '/tmp/tdm')
+tdm_metafile = compile_to_hardware([copy.copy(seq)], 'tmp/tdm')
 tdm_metadata = json.loads(open(tdm_metafile).read())
 
 tdm_instr = QGL.drivers.APS2TDMPattern.tdm_instructions(seq)


### PR DESCRIPTION
Temporary solution to include the TDM file in the metainfo. Clearly this is not ideal because it messes with the config, which is static. Any suggestions? Should we add something to the channel library that indicates whether a TDM is the master and needs to load a sequence?