### PR TITLE
Align pulses instead of blocks

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -154,11 +154,11 @@ def pull_uniform_entries(entries, entry_iterators):
         if all(iterDone):
             raise StopIteration("Unable to find a uniform set of entries")
 
-        if all(x == lengths[0] for x in lengths):
+        if all(np.isclose(x, lengths[0], atol=1e-10) for x in lengths):
             break
 
         #Otherwise try to concatenate on entries to match lengths
-        while lengths[ct] < max(lengths):
+        while not np.isclose(lengths[ct], max(lengths), atol=1e-10):
             # concatenate with following entry to make up the length difference
             try:
                 next_entry = next(entry_iterators[ct])

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -20,7 +20,7 @@ import hashlib, collections
 import pickle
 from copy import copy
 
-from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse, CompoundGate
+from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse, CompoundGate, align_p
 from .PulsePrimitives import BLANK
 from . import ControlFlow
 from . import BlockLabel
@@ -201,9 +201,7 @@ def add_digitizer_trigger(seqs):
                     trig_chan = chan.trig_chan
                     if not (hasattr(seq[ct], 'pulses') and
                             trig_chan in seq[ct].pulses.keys()):
-                        seq[ct] *= TAPulse("TRIG", trig_chan,
-                                           trig_chan.pulse_params['length'], 1.0,
-                                           0.0, 0.0)
+                        seq[ct] = align_p('left', seq[ct], TAPulse("TRIG", trig_chan, trig_chan.pulse_params['length'], 1.0, 0.0, 0.0))
 
 
 def contains_measurement(entry):
@@ -229,9 +227,7 @@ def add_slave_trigger(seqs, slaveChan):
         while ct < len(seq) - 1:
             if isinstance(seq[ct], ControlFlow.Wait):
                 try:
-                    seq[ct + 1] *= TAPulse("TRIG", slaveChan,
-                                           slaveChan.pulse_params['length'],
-                                           1.0, 0.0, 0.0)
+                    seq[ct + 1] = align_p('left', seq[ct + 1], TAPulse("TRIG", slaveChan, slaveChan.pulse_params['length'], 1.0, 0.0, 0.0))
                 except TypeError:
                     seq.insert(ct + 1, TAPulse("TRIG", slaveChan,
                                                slaveChan.pulse_params['length'],

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -20,7 +20,7 @@ import hashlib, collections
 import pickle
 from copy import copy
 
-from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse, CompoundGate, align_p
+from .PulseSequencer import Pulse, TAPulse, PulseBlock, CompositePulse, CompoundGate, align
 from .PulsePrimitives import BLANK
 from . import ControlFlow
 from . import BlockLabel
@@ -201,7 +201,7 @@ def add_digitizer_trigger(seqs):
                     trig_chan = chan.trig_chan
                     if not (hasattr(seq[ct], 'pulses') and
                             trig_chan in seq[ct].pulses.keys()):
-                        seq[ct] = align_p('left', seq[ct], TAPulse("TRIG", trig_chan, trig_chan.pulse_params['length'], 1.0, 0.0, 0.0))
+                        seq[ct] = align('left', seq[ct], TAPulse("TRIG", trig_chan, trig_chan.pulse_params['length'], 1.0, 0.0, 0.0))
 
 
 def contains_measurement(entry):
@@ -227,7 +227,7 @@ def add_slave_trigger(seqs, slaveChan):
         while ct < len(seq) - 1:
             if isinstance(seq[ct], ControlFlow.Wait):
                 try:
-                    seq[ct + 1] = align_p('left', seq[ct + 1], TAPulse("TRIG", slaveChan, slaveChan.pulse_params['length'], 1.0, 0.0, 0.0))
+                    seq[ct + 1] = align('left', seq[ct + 1], TAPulse("TRIG", slaveChan, slaveChan.pulse_params['length'], 1.0, 0.0, 0.0))
                 except:
                     seq.insert(ct + 1, TAPulse("TRIG", slaveChan,
                                                slaveChan.pulse_params['length'],

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -228,7 +228,7 @@ def add_slave_trigger(seqs, slaveChan):
             if isinstance(seq[ct], ControlFlow.Wait):
                 try:
                     seq[ct + 1] = align_p('left', seq[ct + 1], TAPulse("TRIG", slaveChan, slaveChan.pulse_params['length'], 1.0, 0.0, 0.0))
-                except TypeError:
+                except:
                     seq.insert(ct + 1, TAPulse("TRIG", slaveChan,
                                                slaveChan.pulse_params['length'],
                                                1.0, 0.0, 0.0))

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -753,18 +753,18 @@ def MeasEcho(qM, qD, delay, piShift=None, phase=0):
     measChan = ChannelLibraries.MeasFactory('M-%s' % qM.label)
     if piShift:
         if piShift > 0:
-            measEcho = align(
+            measEcho =
                 (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
                 reduce(operator.mul,
-                       [Id(q, piShift) + U(q, phase=phase) for q in qD]))
+                       [Id(q, piShift) + U(q, phase=phase) for q in qD])
         elif piShift < 0:
-            measEcho = align(
+            measEcho =
                 (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
                 reduce(operator.mul,
-                       [U(q, phase=phase) + Id(q, -piShift) for q in qD]))
+                       [U(q, phase=phase) + Id(q, -piShift) for q in qD])
     else:
-        measEcho = align((MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
-                         reduce(operator.mul, [U(q, phase=phase) for q in qD]))
+        measEcho = (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
+                         reduce(operator.mul, [U(q, phase=phase) for q in qD])
     measEcho.label = 'MEAS'  #to generate the digitizer trigger
     return measEcho
 

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -717,7 +717,7 @@ def CNOT_simple(source, target, **kwargs):
 def CNOT(source, target, **kwargs):
     cnot_impl = globals()[config.cnot_implementation]
     return cnot_impl(source, target, **kwargs)
- 
+
 ## Measurement operators
 @_memoize
 def MEAS(qubit, **kwargs):
@@ -753,18 +753,11 @@ def MeasEcho(qM, qD, delay, piShift=None, phase=0):
     measChan = ChannelLibraries.MeasFactory('M-%s' % qM.label)
     if piShift:
         if piShift > 0:
-            measEcho =
-                (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
-                reduce(operator.mul,
-                       [Id(q, piShift) + U(q, phase=phase) for q in qD])
+            measEcho = (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) * reduce(operator.mul, [Id(q, piShift) + U(q, phase=phase) for q in qD])
         elif piShift < 0:
-            measEcho =
-                (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
-                reduce(operator.mul,
-                       [U(q, phase=phase) + Id(q, -piShift) for q in qD])
+            measEcho = (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) * reduce(operator.mul, [U(q, phase=phase) + Id(q, -piShift) for q in qD])
     else:
-        measEcho = (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) *
-                         reduce(operator.mul, [U(q, phase=phase) for q in qD])
+        measEcho = (MEAS(qM) + TAPulse('Id', measChan, delay, 0)) * reduce(operator.mul, [U(q, phase=phase) for q in qD])
     measEcho.label = 'MEAS'  #to generate the digitizer trigger
     return measEcho
 

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -88,6 +88,8 @@ class Pulse(namedtuple("Pulse", ["label", "channel", "length", "amp", "phase", "
 
     def __mul__(self, other):
         """ Overload multiplication of Pulses as a "tensor" operator"""
+        if not np.isclose(self.length, other.length):
+            return align_p('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)
 
@@ -220,7 +222,7 @@ class PulseBlock(object):
             else:
                 result.pulses[k] = v
         result.length = max(self.length, rhs.length)
-        return align('center', result)
+        return result
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -153,6 +153,11 @@ class CompositePulse(namedtuple("CompositePulse", ["label", "pulses"])):
             return CompositePulse("", self.pulses + [other])
 
     def __mul__(self, other):
+        if not np.isclose(self.length, other.length, atol=1e-10):
+            if self.length == 0 or other.length == 0:
+                return align_p('left', self, other)
+            else:
+                return align_p('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)
 

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -260,12 +260,8 @@ def align_p(mode="center", *pulses):
     # Align any number of Pulses
     # TODO: First, make everything look like a sequence of pulses
     def flatten_to_pulses(obj):
-        import pdb; pdb.set_trace()
-        if isinstance(obj, Pulse):
+        if isinstance(obj, Pulse) or isinstance(obj, CompositePulse):
             yield obj
-        elif isinstance(obj, CompositePulse):
-            for pulse in obj.pulses:
-                yield from flatten_to_pulses(pulse)
         else:
             for pulse in obj.pulses.values():
                 yield from flatten_to_pulses(pulse)
@@ -275,7 +271,7 @@ def align_p(mode="center", *pulses):
     pulse_list = []
     for k,pulse in enumerate(pulses):
        if isinstance(pulse, PulseBlock):
-           pulse_list.append(list(flatten_to_pulses(pulse))) #TODO: flatten the list
+           pulse_list += list(flatten_to_pulses(pulse))
        else:
            pulse_list.append(pulse)
     if max(pad_lengths) == 0:

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -88,7 +88,7 @@ class Pulse(namedtuple("Pulse", ["label", "channel", "length", "amp", "phase", "
 
     def __mul__(self, other):
         """ Overload multiplication of Pulses as a "tensor" operator"""
-        if not np.isclose(self.length, other.length):
+        if not np.isclose(self.length, other.length, atol=1e-10):
             return align_p('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -90,9 +90,9 @@ class Pulse(namedtuple("Pulse", ["label", "channel", "length", "amp", "phase", "
         """ Overload multiplication of Pulses as a "tensor" operator"""
         if not np.isclose(self.length, other.length, atol=1e-10):
             if self.length == 0 or other.length == 0:
-                return align_p('left', self, other)
+                return align('left', self, other)
             else:
-                return align_p('center', self, other)
+                return align('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)
 
@@ -155,9 +155,9 @@ class CompositePulse(namedtuple("CompositePulse", ["label", "pulses"])):
     def __mul__(self, other):
         if not np.isclose(self.length, other.length, atol=1e-10):
             if self.length == 0 or other.length == 0:
-                return align_p('left', self, other)
+                return align('left', self, other)
             else:
-                return align_p('center', self, other)
+                return align('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)
 
@@ -258,13 +258,7 @@ class PulseBlock(object):
         else:
             ptype(self)
 
-def align(pulseBlock, mode="center"):
-    # make sure we have a PulseBlock
-    pulseBlock = pulseBlock.promote(PulseBlock)
-    pulseBlock.alignment = mode
-    return pulseBlock
-
-def align_p(mode="center", *pulses):
+def align(mode="center", *pulses):
     # Align any number of Pulses
     # TODO: First, make everything look like a sequence of pulses
     def flatten_to_pulses(obj):

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -290,7 +290,7 @@ class CompoundGate(object):
     '''
     A wrapper around a python list to allow us to define '*' on lists.
     Used by multi-pulse structures like CNOT_CR so that we can retain the
-    "boundaries" of the oepration.
+    "boundaries" of the operation.
     '''
     def __init__(self, seq, label=None):
         if isinstance(seq, list):
@@ -352,6 +352,10 @@ class CompoundGate(object):
     def promote(self, ptype):
         # CompoundGates cannot be promoted
         return self
+
+    @property
+    def length(self):
+        return sum(p.length for p in self)
 
 def promote_type(lhs, rhs):
     '''

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -281,11 +281,11 @@ def align_p(mode="center", *pulses):
         # no padding element required
         return pulses
     elif mode == 'left':
-        return reduce(operator.mul,[p + TAPulse('Id', p.channel, round(max(pulse_lengths) - p.length,9),0) if p.length < max(pulse_lengths) else p for p in pulse_list])
+        return reduce(operator.mul,[p + TAPulse('Id', p.channel, max(pulse_lengths) - p.length,0) if p.length < max(pulse_lengths) else p for p in pulse_list])
     elif mode == 'right':
-        return reduce(operator.mul,[TAPulse('Id', p.channel, round(max(pulse_lengths) - p.length,9),0) + p if p.length < max(pulse_lengths) else p for p in pulse_list])
+        return reduce(operator.mul,[TAPulse('Id', p.channel, max(pulse_lengths) - p.length,0) + p if p.length < max(pulse_lengths) else p for p in pulse_list])
     elif mode == 'center':
-        return reduce(operator.mul,[TAPulse('Id', p.channel, round((max(pulse_lengths) - p.length)/2,9),0) + p + TAPulse('Id', p.channel, round((max(pulse_lengths) - p.length)/2,9),0) if p.length < max(pulse_lengths) else p for p in pulse_list])
+        return reduce(operator.mul,[TAPulse('Id', p.channel, (max(pulse_lengths) - p.length)/2,0) + p + TAPulse('Id', p.channel, (max(pulse_lengths) - p.length)/2,0) if p.length < max(pulse_lengths) else p for p in pulse_list])
     else:
         logger.error('Pulse alignment type must be one of left, right, or center.')
 

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -89,7 +89,10 @@ class Pulse(namedtuple("Pulse", ["label", "channel", "length", "amp", "phase", "
     def __mul__(self, other):
         """ Overload multiplication of Pulses as a "tensor" operator"""
         if not np.isclose(self.length, other.length, atol=1e-10):
-            return align_p('center', self, other)
+            if self.length == 0 or other.length == 0:
+                return align_p('left', self, other)
+            else:
+                return align_p('center', self, other)
         ptype = promote_type(self, other)
         return self.promote(ptype) * other.promote(ptype)
 
@@ -355,7 +358,8 @@ class CompoundGate(object):
 
     @property
     def length(self):
-        return sum(p.length for p in self)
+        return self.seq[0].length #hack to support left-alignment e.g. for triggers). General alignment of CompoundGates not yet implemented
+        #sum(p.length for p in self.seq)
 
 def promote_type(lhs, rhs):
     '''

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -2,7 +2,7 @@ from .Channels import Qubit, Measurement, Edge
 from .ChannelLibraries import QubitFactory, MeasFactory, EdgeFactory, MarkerFactory, ChannelLibrary, channelLib
 from .PulsePrimitives import *
 from .Compiler import compile_to_hardware, set_log_level
-from .PulseSequencer import align, align_p
+from .PulseSequencer import align, align
 from .ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync, Barrier
 from .BasicSequences import *
 from .Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -2,7 +2,7 @@ from .Channels import Qubit, Measurement, Edge
 from .ChannelLibraries import QubitFactory, MeasFactory, EdgeFactory, MarkerFactory, ChannelLibrary, channelLib
 from .PulsePrimitives import *
 from .Compiler import compile_to_hardware, set_log_level
-from .PulseSequencer import align
+from .PulseSequencer import align, align_p
 from .ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync, Barrier
 from .BasicSequences import *
 from .Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -60,7 +60,7 @@ class CompileUtils(unittest.TestCase):
         assert (seq1 == [qwait(), t, label, X90(q1)])
 
         PatternUtils.add_slave_trigger([seq2], trigger)
-        assert (seq2 == [qwait(), align_p('left', X90(q1), t)])
+        assert (seq2 == [qwait(), align('left', X90(q1), t)])
 
     def test_concatenate_entries(self):
         q1 = self.q1

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -54,14 +54,13 @@ class CompileUtils(unittest.TestCase):
         label = BlockLabel.newlabel()
         seq1 = [qwait(), label, X90(q1)]
         seq2 = [qwait(), X90(q1)]
-
         PatternUtils.add_slave_trigger([seq1], trigger)
         t = TAPulse("TRIG", trigger, trigger.pulse_params['length'], 1.0, 0.0,
                     0.0)
         assert (seq1 == [qwait(), t, label, X90(q1)])
 
         PatternUtils.add_slave_trigger([seq2], trigger)
-        assert (seq2 == [qwait(), X90(q1) * t])
+        assert (seq2 == [qwait(), align_p('left', X90(q1), t)])
 
     def test_concatenate_entries(self):
         q1 = self.q1
@@ -84,7 +83,7 @@ class CompileUtils(unittest.TestCase):
         entries = [next(e) for e in entryIterators]
         entries, max_length = Compiler.pull_uniform_entries(entries, entryIterators)
         self.assertAlmostEqual(max_length, 60e-9)
-        assert all(e.length == max_length for e in entries)
+        assert all(np.isclose(e.length, max_length, atol=1e-10) for e in entries)
         self.assertRaises(StopIteration, next, entryIterators[0])
 
         q2.pulse_params['length'] = 40e-9
@@ -107,7 +106,7 @@ class CompileUtils(unittest.TestCase):
         entries = [next(e) for e in entryIterators]
         entries, max_length = Compiler.pull_uniform_entries(entries, entryIterators)
         self.assertAlmostEqual(max_length, 120e-9)
-        self.assertTrue(all(e.length == max_length for e in entries))
+        self.assertTrue(all(np.isclose(e.length, max_length, atol=1e-10) for e in entries))
 
     def test_merge_channels(self):
         q1 = self.q1
@@ -119,7 +118,7 @@ class CompileUtils(unittest.TestCase):
 
         chLL = Compiler.merge_channels(ll, [q1, q2])
         assert len(chLL[0]) == len(ll[q1][0]) - 2
-        assert len(chLL[0]) == len(ll[q2][0]) - 1
+        assert len(chLL[0]) == len(ll[q2][0])
 
     def test_num_measurements(self):
         q1 = self.q1

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -155,7 +155,7 @@ class MultiQubitTestCases(SequenceTestCases):
         self.sequences['operators'] = [X90(q1), X(q1) * Y(q2), CNOT_simple(q1, q2),
                                        Xm(q2), Y(q1) * X(q2)]
 
-        self.sequences['align'] = [align_p('right',
+        self.sequences['align'] = [align('right',
             X90(q1), Xtheta(q2, amp=0.5, length=100e-9)), Y90(q1) * Y90(q2)]
 
         flipFlop = X(q1) + X(q1)

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -155,12 +155,11 @@ class MultiQubitTestCases(SequenceTestCases):
         self.sequences['operators'] = [X90(q1), X(q1) * Y(q2), CNOT_simple(q1, q2),
                                        Xm(q2), Y(q1) * X(q2)]
 
-        self.sequences['align'] = [align(
-            X90(q1) * Xtheta(q2, amp=0.5, length=100e-9),
-            'right'), Y90(q1) * Y90(q2)]
+        self.sequences['align'] = [align_p('right',
+            X90(q1), Xtheta(q2, amp=0.5, length=100e-9)), Y90(q1) * Y90(q2)]
 
         flipFlop = X(q1) + X(q1)
-        self.sequences['composite'] = [align(flipFlop * Y(q2)), Y90(q1)]
+        self.sequences['composite'] = [flipFlop*Y(q2), Y90(q1)]
 
 # unittest classes
 


### PR DESCRIPTION
Alternative solution to the issue presented in https://github.com/BBN-Q/QGL/pull/92. This allows to specify any alignment between pulses using `align(mode, pulse1, pulse2)`. `mode` can be either 'left', 'center' (default), or 'right'. `pulse1` and `pulse2` can be any combination of `Pulse`, `PulseBlock`, `CompositePulse`. The alignment of `CompoundGates` is currently not supported (limited workaround for triggers). 

Note: this does not solve https://github.com/BBN-Q/QGL/issues/148, but it's a step towards more flexibility. 

Thoughts?

