### PR TITLE
Define digitizer triggers as markers

### DIFF
--- a/QGL/ChannelLibraries.py
+++ b/QGL/ChannelLibraries.py
@@ -330,7 +330,9 @@ class ChannelLibrary(Atom):
                 meas_instr, meas_chan = qubit["measure"]["AWG"].split()
                 params = {k: v for k,v in qubit["measure"].items() if k in Channels.Measurement.__atom_members__.keys()}
                 params["label"]        = "M-{}".format(name)
-                params["trig_chan"]     = "digTrig-" + qubit["measure"]["trigger"]
+                # parse the digitizer trigger from the marker dictionary, if available. If not, expected in the form Instr Ch
+                dig_trig = trigger_dict.get(qubit["measure"]["trigger"], qubit["measure"]["trigger"]) if trigger_dict else qubit["measure"]["trigger"]
+                params["trig_chan"]     = "digTrig-" + dig_trig
                 params["phys_chan"]     = meas_instr + "-" + meas_chan
                 params["meas_type"]     = "autodyne"
                 params["receiver_chan"] = "RecvChan-" + qubit["measure"]["receiver"]
@@ -345,9 +347,9 @@ class ChannelLibrary(Atom):
                     if len(qubit["measure"]["receiver"].split()) != 1:
                         print("Receiver specification for {} ({}) must have a stream selector".format(name, qubit["measure"]["receiver"]))
                         raise ValueError("Receiver specification for {} ({}) must have a stream selector".format(name, qubit["measure"]["receiver"]))
-                    phys_instr, phys_marker = qubit["measure"]["trigger"].split()
+                    phys_instr, phys_marker = dig_trig.split()
                     params = {}
-                    params["label"]        = "digTrig-" + qubit["measure"]["trigger"]
+                    params["label"]        = "digTrig-" + dig_trig
                     params["phys_chan"]     = phys_instr + "-" + phys_marker
                     if params["phys_chan"] in marker_lens.keys():
                         length = marker_lens[params["phys_chan"]]


### PR DESCRIPTION
Optionally declare the digitizer triggers in the markers section of the yaml configuration. 
For instance:

```
q1:
    measure:
      AWG: APSII1 12
      trigger: digitizerTrig
      ...
```


```
markers:
  digitizerTrig: APSII1 12m1
```

Alternatively, writing directly `trigger: APSII1 12m1` is still valid. 

