### PR TITLE
Update 2q Cliffords to CompoundGates

### DIFF
--- a/QGL/Cliffords.py
+++ b/QGL/Cliffords.py
@@ -180,10 +180,10 @@ def entangling_seq(gate, q1, q2):
     if gate == "CNOT":
         return ZX90_CR(q2, q1)
     elif gate == "iSWAP":
-        return ZX90_CR(q2, q1) + [Y90m(q1) * Y90m(q2)] + ZX90_CR(q2, q1)
+        return [ZX90_CR(q2, q1) , Y90m(q1) * Y90m(q2), ZX90_CR(q2, q1)]
     elif gate == "SWAP":
-        return ZX90_CR(q2, q1) + [Y90m(q1) * Y90m(q2)] + ZX90_CR(
-            q2, q1) + [(X90(q1) + Y90m(q1)) * X90(q2)] + ZX90_CR(q2, q1)
+        return [ZX90_CR(q2, q1), Y90m(q1) * Y90m(q2), ZX90_CR(
+            q2, q1), (X90(q1) + Y90m(q1)) * X90(q2), ZX90_CR(q2, q1)]
 
 
 def entangling_mat(gate):


### PR DESCRIPTION
Some of the 2-q Cliffords were still implemented with the CNOT gates as pulse lists, instead of the current implementation as [CompoundGates](https://github.com/BBN-Q/QGL/pull/103)