### PR TITLE
Remove receivers with 0 measurements

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -456,7 +456,7 @@ def compile_to_hardware(seqs,
         }]
     receiver_measurements = {}
     for wire, n in wire_measurements.items():
-        if wire.receiver_chan:
+        if wire.receiver_chan and n>0:
             receiver_measurements[wire.receiver_chan.label] = n
     meta = {
         'instruments': files,

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -211,7 +211,7 @@ def add_digitizer_trigger(seqs):
 
 def contains_measurement(entry):
     """
-    Determines if a LL entry contains a measurement
+    Determines if a LL entry contains a measurement (with a digitizer trigger)
     """
     if hasattr(entry, 'label') and entry.label == "MEAS":
         return True


### PR DESCRIPTION
If the digitizer trigger is disabled: MEAS(dig_trig = None),
the number of measurements for that receiver could be 0. In this case, we now remove the receiver entry entirely