### PR TITLE
More generic cal_descriptor

### DIFF
--- a/QGL/BasicSequences/helpers.py
+++ b/QGL/BasicSequences/helpers.py
@@ -34,8 +34,7 @@ def create_cal_seqs(qubits, numRepeats, measChans=None, waitcmp=False, delay=Non
         [cal_seq.append(qwait(kind='CMP')) for cal_seq in full_cal_seqs]
     return full_cal_seqs
 
-def cal_descriptor(qubits, numRepeats, partition=2):
-    states = ['0', '1']
+def cal_descriptor(qubits, numRepeats, partition=2, states = ['0', '1']):
     # generate state set in same order as we do above in create_cal_seqs()
     state_set = [reduce(operator.add, s) for s in product(states, repeat=len(qubits))]
     descriptor = {


### PR DESCRIPTION
Allow cal descriptor for arbitrary state preparation e.g. using |2>