### PR TITLE
Fix/unit tests 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ The QGL config file will be created the first time you run `import QGL` or `from
 * networkx
 * iPython/Jupyter 4.0 (only for Jupyter notebooks)
 * ruamel_yaml
+
+## UnitTest data support
+This repository uses the Git Large File Storage (LFS) extension to manage a few
+UnitTest data files (see https://git-lfs.github.com/).

--- a/ReadMe_Docs.txt
+++ b/ReadMe_Docs.txt
@@ -1,0 +1,6 @@
+#---------- 14 Nov 2018
+This repository uses the MkDocs (v0.17.2) utilities for documentation rendering.
+From the repo root directory, "mkdocs --help" shows the options.
+"mkdocs build" for example, writes a set of html documents under the ./site subdirectory
+
+(Aside: ./site is NOT currently in the .gitignore file; insertion pending for consistency). 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: QGL
-pages:
+nav:
     - Intro: index.md
     - Configuration: config.md
     - Examples: examples.md

--- a/renderDocs.sh
+++ b/renderDocs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo ""
+echo "#---------- $0 (QGL) start..."
+echo ""
+#----- Simple script to capture basic documentation rendering logic.
+
+echo "#-----Building QGL docs via ~:"
+
+export CMD="mkdocs build"
+echo $CMD
+echo ""
+$CMD
+
+pushd .
+
+cd site
+echo ""
+echo "Target QGL documents list as follows:"
+pwd
+ls -l
+
+
+echo ""
+echo "#---------- $0 (QGL) stop."
+echo ""
+

--- a/runUnitTests.sh
+++ b/runUnitTests.sh
@@ -61,7 +61,9 @@ fi
 
 echo ""
 echo "#----- Testing LFS data file dependent QGL modules via ~:"
-export CMD="python -m unittest tests.test_QGL tests.test_Sequences.py -v -f"
+# Careful -- in this format (tests.moduleName) DON'T cite the .py suffix
+# (it will render an odd error regarding missing 'py' attribute)
+export CMD="python -m unittest tests.test_QGL tests.test_Sequences -v -f"
 echo $CMD
 echo ""
 $CMD

--- a/runUnitTests.sh
+++ b/runUnitTests.sh
@@ -2,7 +2,7 @@
 echo ""
 echo "#---------- $0 (QGL) start..."
 echo ""
-#----- Simple script to capture basic documentation rendering logic.
+#----- Simple script to capture unittest preparation and invocation logic.
 
 pwd
 

--- a/runUnitTests.sh
+++ b/runUnitTests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+echo ""
+echo "#---------- $0 (QGL) start..."
+echo ""
+#----- Simple script to capture basic documentation rendering logic.
+
+pwd
+
+export szGit_LFS_Path=`which git-lfs`
+echo "szGit_LFS_Path: [${szGit_LFS_Path}]"
+
+
+# Instantiate the git lfs cached data files...
+export CMD="git lfs pull"
+echo ""
+if [ -z ${szGit_LFS_Path} ]; then
+    echo ""
+    echo "#--------------------"
+    echo "#   W A R N I N G   -- git-lfs extension library unavailable;"
+    echo "#                      -- QGL h5 data file processing may fail."
+    echo "#                         << [${szGit_LFS_Path}] << 'which git-lfs'"
+    echo "#--------------------"
+else
+    echo "git-lfs available;  retrieving/instantiating cached QGL h5 data files via ~:"
+    echo $CMD
+    echo ""
+    $CMD
+fi
+echo ""
+
+
+# Don't forget to set the BBN_MEAS_FILE reference.
+export BBN_MEAS_FILE=tests/test_measure.yml
+
+echo ""
+echo "#-----Unit-Testing general QGL (BBN_MEAS_FILE=${BBN_MEAS_FILE}) via ~:"
+# -f option fails fast
+#export CMD="python -m unittest discover . -v -f"
+#export CMD="python -m unittest discover . -v"
+# Trimm'ed down (non LFS unitest calls) syntax as follows:
+export CMD="python -m unittest  tests/test_A*.py tests/test_C*.py tests/test_Scheduler.py tests/test_config.py tests/test_pulse_types.py -v"
+echo $CMD
+echo ""
+$CMD
+
+if [ -z ${szGit_LFS_Path} ]; then
+    echo ""
+    echo "#-----   W A R N I N G:"
+    echo "    Fast-failing unittest modules test_QGL.py, and test_Sequences.py,"
+    echo "    currently, due to git lfs data file dependencies;  in-short, the"
+    echo "    docker continuumio/miniconda load appears to omit the necessary"
+    echo "    git-lfs library installation."
+    echo ""
+    echo "    Without the git-lfs library extension, h5 data calls from these"
+    echo "    modules typically error out with ~:"
+    echo "    OSError: Unable to open file (file signature not found)"
+    echo ""
+    echo "    If/when the git-lfs library becomes available in the docker load, "
+    echo "    remove the \"-f\"from the invocation, below:"
+fi
+
+echo ""
+echo "#----- Testing LFS data file dependent QGL modules via ~:"
+export CMD="python -m unittest tests.test_QGL tests.test_Sequences.py -v -f"
+echo $CMD
+echo ""
+$CMD
+
+echo ""
+echo "#---------- $0 (QGL) stop."
+echo ""
+

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -88,7 +88,21 @@ class SequenceTestCases(object):
                     'Warning: valid waveform file for {0} not found at: {1}'.format(
                         caseName, fileName))
                 continue
+            # -----
+            # print( "\n\rDBG::Calling \"with h5py.File( {0}, 'r')\"...".format( fileName) )
+            # -----
+            # The following pulls in Git Large File Storage (LFS) data files
+            # from cached signature references;  if the h5py.File call fails
+            # with an OSError, double-check git-lfs library installation (in
+            # addition to git) -- <https://git-lfs.github.com/>
+            #
+            # Where git-lfs was NOT installed the h5py.File() call was observed
+            # returning:
+            #
+            # OSError: Unable to open file (file signature not found))
+            #
             with h5py.File(fileName, 'r') as FID:
+                # print( "DBG::FID: {0}".format( FID))
                 for name, waveform in FID['/channels'].items():
                     validWaveform[name] = waveform[:]
             self.validWaveforms[caseName] = validWaveform

--- a/tests/test_Scheduler.py
+++ b/tests/test_Scheduler.py
@@ -121,3 +121,6 @@ class SchedulerTest(unittest.TestCase):
 
         # should be unchanged
         assert seq == result
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -8,6 +8,11 @@ import QGL
 from QGL.Channels import Edge, Measurement, LogicalChannel, LogicalMarkerChannel, PhysicalMarkerChannel, PhysicalQuadratureChannel
 from QGL.drivers import APSPattern, APS2Pattern, TekPattern
 
+# Pulled in logger to help debug stand-alone run issue with the config.AWGDir
+# (the configuration was NOT gettng loaded when run independently)
+#
+import logging
+logger = logging.getLogger( 'sequences')
 
 class AWGTestHelper(object):
     testFileDirectory = './tests/test_data/awg/'
@@ -92,6 +97,13 @@ class AWGTestHelper(object):
 
     def set_awg_dir(self, footer=""):
         cn = self.__class__.__name__
+
+        if None == QGL.config.AWGDir:
+            logger.warning( "\n\r#----- EEE NULL QGL.config.AWGDir {%s} cited; calling load_config()...", QGL.config.AWGDir)
+            QGL.config.load_config()
+            logger.warning( "#----- Post load-config QGL.config.AWGDir: {%s}.\n\r", QGL.config.AWGDir)
+        #else:
+        #    logger.warning( "\n\r#----- Using QGL.config.AWGDir {%s} 8-p", QGL.config.AWGDir)
 
         self.awg_dir = os.path.abspath(QGL.config.AWGDir + os.path.sep + cn)
         self.truth_dir = os.path.abspath(self.testFileDirectory + os.path.sep +

--- a/tests/test_pulse_types.py
+++ b/tests/test_pulse_types.py
@@ -16,7 +16,9 @@ class PulseTypes(unittest.TestCase):
         self.q3 = QubitFactory('q3')
         self.q4 = QubitFactory('q4')
 
-    @unittest.skip("Type promition for CNOT(q1, q2) * X(q3) gives PulseBlock not CompoundGate. Looking into this issue.")
+    # This appears to run successfully with the skip commented out;
+    # TJR, 07 Nov 2018
+    #@unittest.skip("Type promition for CNOT(q1, q2) * X(q3) gives PulseBlock not CompoundGate. Looking into this issue.")
     def test_promotion_rules(self):
         q1, q2, q3, q4 = self.q1, self.q2, self.q3, self.q4
 
@@ -28,3 +30,8 @@ class PulseTypes(unittest.TestCase):
         assert( type(CNOT_CR(q1, q2) * X(q3)) == CompoundGate )
         assert( type(X(q3) * CNOT_CR(q1, q2)) == CompoundGate )
         assert( type(CNOT_CR(q1, q2) * CNOT_CR(q3, q4)) == CompoundGate )
+
+# Added to support simple python invocation
+#
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added subtle tweaks to some of the unit test files and warning logic regarding required LFS proxied data files.
Also defined renderDocs.sh and runUnitTests.sh shell scripts to simplify / standardize setup for document rendering and unitTest (discovery) invocations (intended for use from bbnqconda testing).