### PR TITLE
if the "kind" is unknown, raise an exception

### DIFF
--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -97,6 +97,7 @@ def qwait(kind="TRIG", addr=None, channels=None):
             raise Exception('Please specify address')
         return [WriteAddrInstruction('INVALIDATE', None, 1, addr, 0xffffffff, False), LoadCmpVramInstruction('LOADCMPVRAM', 1, addr, 0xff, False)]
 
+    raise Exception('Unknown kind parameter [%s]' % str(kind))
 
 
 def qsync(channels=None):

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -94,10 +94,10 @@ def qwait(kind="TRIG", addr=None, channels=None):
         return LoadCmp(channels)
     elif kind == "RAM":
         if addr is None:
-            raise Exception('Please specify address')
+            raise ValueError('Please specify addr')
         return [WriteAddrInstruction('INVALIDATE', None, 1, addr, 0xffffffff, False), LoadCmpVramInstruction('LOADCMPVRAM', 1, addr, 0xff, False)]
 
-    raise Exception('Unknown kind parameter [%s]' % str(kind))
+    raise ValueError('Unknown kind parameter [%s]' % str(kind))
 
 
 def qsync(channels=None):

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -90,6 +90,23 @@ class ControlFlowTest(unittest.TestCase):
         assert (isinstance(seq1[2][0], TdmInstructions.WriteAddrInstruction))
         assert (isinstance(seq1[2][1], TdmInstructions.LoadCmpVramInstruction))
 
+    def test_qwait_err(self):
+        q1 = self.q1
+        with self.assertRaises(ValueError) as exc:
+            seq1 = [qwait(kind='FOO')]
+        exc_str = str(exc.exception)
+        assert (exc_str == 'Unknown kind parameter [FOO]')
+
+        with self.assertRaises(ValueError) as exc:
+            seq1 = [qwait(kind='RAM')]
+        exc_str = str(exc.exception)
+        assert (exc_str == 'Please specify addr')
+
+        # test the legal values
+        seq1 = [qwait(kind='TRIG')]
+        seq1 = [qwait(kind='CMP')]
+        seq1 = [qwait(kind='RAM', addr=0xff)]
+
     def test_compile(self):
         q1 = self.q1
         seq1 = [X90(q1), Y90(q1)]


### PR DESCRIPTION
this will usually detect when someone is calling qwait the old way,
and raise an error that will require correction