### PR TITLE
Revert to old stream labels

### DIFF
--- a/QGL/ChannelLibraries.py
+++ b/QGL/ChannelLibraries.py
@@ -366,7 +366,7 @@ class ChannelLibrary(object):
         chans = []
 
         for p, d, s in itertools.product(phys_channels, dsp_channels, stream_types):
-            chans.append(Channels.ReceiverChannel(label=f"RecvChan-{label}-{s}-{d}-{p}",
+            chans.append(Channels.ReceiverChannel(label=f"RecvChan-{label}-{s}-{p}-{d}",
                             channel=p, dsp_channel=d, stream_type=s,
                             channel_db=self.channelDatabase))
 


### PR DESCRIPTION
For consistency with https://github.com/BBN-Q/libx6/blob/master/doc/01_Usage.md, I'd rather label first physical, then dsp channel