### PR TITLE
Fixes for adding stream selectors back in

### DIFF
--- a/QGL/config.py
+++ b/QGL/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("QGL")
 if os.getenv('AWG_DIR'):
     AWGDir = os.getenv('AWG_DIR')
 else:
-    logger.warning("Defaulting to temporary directory for AWG sequence file outputs.")
+    logger.warning("AWG_DIR environment variable not defined. Unless otherwise specified, using temporary directory for AWG sequence file outputs.")
     AWGDir = tempfile.mkdtemp(prefix="AWG")
 
 # The db file, where the channel libraries are stored


### PR DESCRIPTION
DSP content no longer the purview of the channel library. QGL only needs to know which physical receiver channel is being used.