### PR TITLE
Apply frame change at start of seq. if necessary

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -634,6 +634,14 @@ def compile_sequence(seq, channels=None):
                         updated_frameChange = wires[chan][-ct].frameChange + block.pulses[chan].frameChange
                         wires[chan][-ct] = wires[chan][-ct]._replace(frameChange=updated_frameChange)
                         break
+                    # if no non-TA entry, add frame change at first available opportunity, from the start moving forward
+                    if ct == len(wires[chan]):
+                        for ct2 in range(len(wires[chan])):
+                            if hasattr(wires[chan][ct2], 'frameChange'):
+                                if hasattr(wires[chan][ct2], 'isTimeAmp') and  wires[chan][ct2].isTimeAmp:
+                                    updated_frameChange = wires[chan][ct2].frameChange + block.pulses[chan].frameChange
+                                    wires[chan][ct2] = wires[chan][ct2]._replace(frameChange=updated_frameChange)
+                                break # if the first pulse is not an Id left, it should have already been updated
             continue
         # add the pulses per channel
         for chan in channels:


### PR DESCRIPTION
This can be necessary when a ZX90 involving that target qubit has already been applied, e.g.: `ZX90(q1,q2), Z(q2), X(q2)` would cause no phase shift until now because there are no no-TA pulses preceding `Z(q2)` on that channel.

This should solve at least one of the issues with the tests @matthewware @luke-govia @gribeill 
