### PR TITLE
Compile step for simultaneous pulses

### DIFF
--- a/QGL/ChannelLibraries.py
+++ b/QGL/ChannelLibraries.py
@@ -673,6 +673,12 @@ class ChannelLibrary(object):
         return thing
 
     @check_for_duplicates
+    def new_logical_channel(self, label, **kwargs):
+        thing = Channels.LogicalChannel(label=label, channel_db=self.channelDatabase, **kwargs)
+        self.add_and_update_dict(thing)
+        return thing
+
+    @check_for_duplicates
     def new_marker(self, label, phys_chan, **kwargs):
         thing = Channels.LogicalMarkerChannel(label=label, phys_chan = phys_chan, channel_db=self.channelDatabase, **kwargs)
         self.add_and_update_dict(thing)

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -344,6 +344,7 @@ def compile_to_hardware(seqs,
     # Add gating/blanking pulses
     logger.info("Adding blanking pulses")
     for seq in seqs:
+        PatternUtils.add_parametric_pulses(seq)
         PatternUtils.add_gate_pulses(seq)
 
     if add_slave_trigger and 'slave_trig' in ChannelLibraries.channelLib:


### PR DESCRIPTION
e.g. parametric drives that need to be applied simultaneously to other pulses. 
One can set the field `q1.parametric_chan = p`, where `p` is the `LogicalChannel` of choice (for now defined as a dummy qubit) to have pulses on `p` applied simultaneously to those on `q1`. 