### PR TITLE
Fix/mandatory db resource name

### DIFF
--- a/QGL/ChannelLibraries.py
+++ b/QGL/ChannelLibraries.py
@@ -91,10 +91,24 @@ def check_for_duplicates(f):
 
 class ChannelLibrary(object):
 
-    def __init__(self, db_resource_name=":memory:", db_provider="sqlite"):
-        """Create the channel library."""
+    def __init__(self, db_resource_name):
+        """Create the channel library.
+        db_resource_name is the filename (without suffix) of the sqlite database use for the channel library.
+        The .sqlite suffix will automatically be added. Optionally one can be ":memory:" for a purely in-memory
+        database.
+        """
+        db_provider="sqlite"
 
         global channelLib
+
+        if ".sqlite" not in db_resource_name:
+            db_resource_name += ".sqlite"
+
+        if db_resource_name is not ":memory:":
+            if not os.path.isabs(db_resource_name):
+                db_resource_name = os.path.abspath(db_resource_name)
+
+        logger.info(f"Intializing database at {db_provider}:///{db_resource_name}")
 
         bbndb.initialize_db(f'{db_provider}:///{db_resource_name}')
         self.session = bbndb.get_cl_session()

--- a/doc/ex1_QGL_basics.ipynb
+++ b/doc/ex1_QGL_basics.ipynb
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(\"example.sqlite\")\n",
+    "cl = ChannelLibrary(\"example\")\n",
     "\n",
     "# This would be a temporary, in memory database\n",
     "# cl = ChannelLibrary(\":memory:\")"

--- a/doc/ex1_QGL_basics.ipynb
+++ b/doc/ex1_QGL_basics.ipynb
@@ -51,10 +51,10 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\"example.sqlite\")\n",
+    "cl = ChannelLibrary(\"example.sqlite\")\n",
     "\n",
     "# This would be a temporary, in memory database\n",
-    "# cl = ChannelLibrary(db_resource_name=\":memory:\")"
+    "# cl = ChannelLibrary(\":memory:\")"
    ]
   },
   {

--- a/doc/ex2_single-qubit_sequences.ipynb
+++ b/doc/ex2_single-qubit_sequences.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\"example.sqlite\")"
+    "cl = ChannelLibrary(\"example.sqlite\")"
    ]
   },
   {

--- a/doc/ex2_single-qubit_sequences.ipynb
+++ b/doc/ex2_single-qubit_sequences.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(\"example.sqlite\")"
+    "cl = ChannelLibrary(\"example\")"
    ]
   },
   {

--- a/doc/ex3_two-qubit_sequences.ipynb
+++ b/doc/ex3_two-qubit_sequences.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\"example.sqlite\")"
+    "cl = ChannelLibrary(\"example.sqlite\")"
    ]
   },
   {

--- a/doc/ex3_two-qubit_sequences.ipynb
+++ b/doc/ex3_two-qubit_sequences.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(\"example.sqlite\")"
+    "cl = ChannelLibrary(\"example\")"
    ]
   },
   {

--- a/doc/ex4_update_in_place.ipynb
+++ b/doc/ex4_update_in_place.ipynb
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "q1 = cl.new_qubit(\"q1\")\n",
     "aps2_1 = cl.new_APS2(\"BBNAPS1\", address=\"192.168.5.101\") \n",
     "aps2_2 = cl.new_APS2(\"BBNAPS2\", address=\"192.168.5.102\")\n",

--- a/doc/example_channel_library.ipynb
+++ b/doc/example_channel_library.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "from QGL import *\n",
     "\n",
-    "cl = ChannelLibrary(\"./example.sqlite\")\n",
+    "cl = ChannelLibrary(\"./example\")\n",
     "q1 = cl.new_qubit(\"q1\")\n",
     "q2 = cl.new_qubit(\"q2\")\n",
     "CNOT12 = cl.new_edge(q1, q2)\n",

--- a/doc/example_channel_library.ipynb
+++ b/doc/example_channel_library.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "from QGL import *\n",
     "\n",
-    "cl = ChannelLibrary(db_resource_name=\"./example.sqlite\")\n",
+    "cl = ChannelLibrary(\"./example.sqlite\")\n",
     "q1 = cl.new_qubit(\"q1\")\n",
     "q2 = cl.new_qubit(\"q2\")\n",
     "CNOT12 = cl.new_edge(q1, q2)\n",

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -115,7 +115,7 @@ programs typically refer only to `Qubit` channels. Actions on other channel
 types may be implied by the operation. For example, to create a `Qubit` object
 in QGL, one can write:
 ```
-cl = ChannelLibrary(db_resource_name=":memory:")
+cl = ChannelLibrary(":memory:")
 q1 = cl.new_qubit("q1")
 ```
 where the Channel Library contains the "physical" information for the logical "qubit" 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 from QGL import *
 
 def setup_test_lib():
-    cl = ChannelLibrary(db_resource_name=":memory:")
+    cl = ChannelLibrary(":memory:")
     cl.clear()
     q1 = cl.new_qubit(label='q1')
     q2 = cl.new_qubit(label='q2')

--- a/tests/test_APS2Pattern.py
+++ b/tests/test_APS2Pattern.py
@@ -10,7 +10,7 @@ from QGL.drivers import APS2Pattern
 
 class APSPatternUtils(unittest.TestCase):
     def setUp(self):
-        self.cl = ChannelLibrary(db_resource_name=":memory:")
+        self.cl = ChannelLibrary(":memory:")
         #self.q1gate = Channels.LogicalMarkerChannel(label='q1-gate',
         #                                    channel_db=self.cl.channelDatabase)
         self.q1 = self.cl.new_qubit(label='q1')

--- a/tests/test_APSPattern.py
+++ b/tests/test_APSPattern.py
@@ -7,7 +7,7 @@ from QGL.drivers import APSPattern
 
 class APSPatternUtils(unittest.TestCase):
     def setUp(self):
-        self.cl = ChannelLibrary(db_resource_name=":memory:")
+        self.cl = ChannelLibrary(":memory:")
         self.q1gate = Channels.LogicalMarkerChannel(label='q1-gate', channel_db=self.cl.channelDatabase)
         self.q1 = self.cl.new_qubit(label='q1')
         self.q1.gate_chan = self.q1gate

--- a/tests/test_Compiler.py
+++ b/tests/test_Compiler.py
@@ -7,7 +7,7 @@ from QGL import *
 class CompileUtils(unittest.TestCase):
     def setUp(self):
         print("Running setup")
-        self.cl = ChannelLibrary(db_resource_name=":memory:")
+        self.cl = ChannelLibrary(":memory:")
         self.cl.clear()
         self.q1gate = Channels.LogicalMarkerChannel(label='q1-gate', channel_db=self.cl.channelDatabase)
         self.q1gate = Channels.LogicalMarkerChannel(label='q1-gate', channel_db=self.cl.channelDatabase)

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -7,7 +7,7 @@ from QGL.BlockLabel import label, endlabel
 
 class ControlFlowTest(unittest.TestCase):
     def setUp(self):
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         self.q1 = cl.new_qubit(label='q1')
         self.q2 = cl.new_qubit(label='q2')
         self.q3 = cl.new_qubit(label='q3')

--- a/tests/test_QGL.py
+++ b/tests/test_QGL.py
@@ -141,7 +141,7 @@ class SingleQubitTestCases(SequenceTestCases):
     fileHeader = 'single'
 
     def newQ1(self):
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         cl.clear()
         q1 = cl.new_qubit("q1")
         q1.pulse_params['length'] = 30e-9
@@ -164,7 +164,7 @@ class MultiQubitTestCases(SequenceTestCases):
 
     def newQubits(self):
         # Create an in-memory blank channel library
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         cl.clear()
         q1 = cl.new_qubit("q1")
         q2 = cl.new_qubit("q2")

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -38,7 +38,7 @@ class AWGTestHelper(object):
         for name, value in mapping.items():
             self.channels[name].phys_chan = self.channels[value]
 
-        self.cl = ChannelLibrary(db_resource_name=":memory:")
+        self.cl = ChannelLibrary(":memory:")
         self.cl.clear()
         self.cl.session.add_all(self.channels.values())
         for chan in self.channels.values():


### PR DESCRIPTION
@gribeill @matthewware As we discussed, moving to a mandatory specification of the db resource using a positional argument, e.g.:

```python
ChannelLibrary("thing") # Creates things.sqlite
```
and not
```python
ChannelLibrary(db_resource_name="thing.sqlite") # No longer valid
```
using `:memory:` still works, but it is no longer the default.