### PR TITLE
Fix/idle gatemod

### DIFF
--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -411,7 +411,7 @@ def WaveformPrefetch(addr):
 def marker_count_bits(count):
     """Marker count to instruction bits"""
     count = int(count)
-    four_count = ((count // ADDRESS_UNIT) - 1) 
+    four_count = ((count // ADDRESS_UNIT) - 1)
     count_rem = count % ADDRESS_UNIT
     return four_count, count_rem
 

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -1201,10 +1201,7 @@ def read_sequence_file(fileName):
                 if modulator_opcode == 0x0:
                     #modulate
                     count = ((instr.payload & 0xffffffff) + 1) * ADDRESS_UNIT
-                    nco_select = {0b001: 0,
-                                  0b010: 1,
-                                  0b011: 2,
-                                  0b100: 3}[nco_select_bits]
+                    nco_select = int(nco_select_bits)-1
                     seqs['mod_phase'][-1] = np.append(
                         seqs['mod_phase'][-1], freq[nco_select] *
                         np.arange(count) + accumulated_phase[nco_select] +

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -1117,7 +1117,6 @@ def read_sequence_file(fileName):
     """
     chanStrs = ['ch1', 'ch2', 'm1', 'mod_phase']
     seqs = {ch: [] for ch in chanStrs}
-
     def start_new_seq():
         for ct, ch in enumerate(chanStrs):
             if (ct < 2) or (ct == 6):
@@ -1202,10 +1201,10 @@ def read_sequence_file(fileName):
                 if modulator_opcode == 0x0:
                     #modulate
                     count = ((instr.payload & 0xffffffff) + 1) * ADDRESS_UNIT
-                    nco_select = {0b0001: 0,
-                                  0b0010: 1,
-                                  0b0100: 2,
-                                  0b1000: 3}[nco_select_bits]
+                    nco_select = {0b001: 0,
+                                  0b010: 1,
+                                  0b011: 2,
+                                  0b100: 3}[nco_select_bits]
                     seqs['mod_phase'][-1] = np.append(
                         seqs['mod_phase'][-1], freq[nco_select] *
                         np.arange(count) + accumulated_phase[nco_select] +
@@ -1215,7 +1214,7 @@ def read_sequence_file(fileName):
                     phase_rad = 2 * np.pi * (instr.payload &
                                              0xffffffff) / 2**27
                     for ct in range(NUM_NCO):
-                        if (nco_select_bits >> ct) & 0x1:
+                        if (int(nco_select_bits)-1 == ct):
                             if modulator_opcode == 0x2:
                                 #reset
                                 next_phase[ct] = 0

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -654,11 +654,11 @@ def inject_modulation_cmds(seqs):
                         nco_select = (list(freqs)).index(entry.frequency) + 1
                         cur_freq = entry.frequency
                     else:
-                        nco_select = mod_seq[-1].nco_select
-                        cur_freq = entry.frequency
-                        if USE_PHASE_OFFSET_INSTRUCTION and (entry.length > 0) and (cur_phase != entry.phase):
-                            mod_seq.append( ModulationCommand("SET_PHASE", nco_select, phase=entry.phase) )
-                            cur_phase = entry.phase
+                        nco_select = 1
+                        #cur_freq = entry.frequency
+                        #if USE_PHASE_OFFSET_INSTRUCTION and (entry.length > 0) and (cur_phase != entry.phase):
+                        #    mod_seq.append( ModulationCommand("SET_PHASE", nco_select, phase=entry.phase) )
+                        #    cur_phase = entry.phase
                     #now apply modulation for count command and waveform command, if non-zero length
                     if entry.length > 0:
                         mod_seq.append(entry)

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -616,7 +616,7 @@ def inject_modulation_cmds(seqs):
         #check whether we have modulation commands
         freqs = np.unique([entry.frequency for entry in filter(lambda s: isinstance(s,Compiler.Waveform) and s.label!='Id', seq)])
         if len(freqs) > 4:
-            raise Exception("Max 2 frequencies on the same channel allowed.")
+            raise Exception("Max 4 frequencies on the same channel allowed.")
         no_freq_cmds = np.all(np.less(np.abs(freqs), 1e-8))
         phases = [entry.phase for entry in filter(lambda s: isinstance(s,Compiler.Waveform) and s.label!='Id', seq)]
         no_phase_cmds = np.all(np.less(np.abs(phases), 1e-8))

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -650,7 +650,7 @@ def inject_modulation_cmds(seqs):
             elif isinstance(entry, Compiler.Waveform):
                 if not no_modulation_cmds:
                     #select nco
-                    if entry.label != 'Id': #Id gate does not to add new frequency
+                    if entry.label != 'Id': #Id gate should not add a new frequency
                         nco_select = (list(freqs)).index(entry.frequency) + 1
                         cur_freq = entry.frequency
                     else:

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -612,7 +612,6 @@ def inject_modulation_cmds(seqs):
     """
     cur_freq = 0
     cur_phase = 0
-#    import pdb;pdb.set_trace();
     for ct,seq in enumerate(seqs):
         #check whether we have modulation commands
         freqs = np.unique([entry.frequency for entry in filter(lambda s: isinstance(s,Compiler.Waveform) and s.label!='Id', seq)])


### PR DESCRIPTION
In the old version any idle gate was creating a new NCO at zero frequency in the compiled sequence. Since the number of NCOs is limited, it looked like a waste. I modified it so that the idle gate simply reuses the frequency of the previous gate, without adding a new one. 
I modified just the APS3 pattern for now, but if it works we can do it for the APS2.