### PR TITLE
Fixed overflow in APS2 and APS3 drivers in numpy > 2.0

### DIFF
--- a/QGL/drivers/APS2Pattern.py
+++ b/QGL/drivers/APS2Pattern.py
@@ -610,16 +610,16 @@ class ModulationCommand(object):
             (nco_select_bits) << NCO_SELECT_OP_OFFSET)
         if self.instruction == "MODULATE":
             #zero-indexed quad count
-            payload |= np.uint32(self.length / ADDRESS_UNIT - 1)
+            payload |= np.uint64(self.length / ADDRESS_UNIT - 1)
         elif self.instruction == "SET_FREQ":
             # frequencies can span -2 to 2 or 0 to 4 in unsigned
-            payload |= np.uint32(
+            payload |= np.uint64(
                 (self.frequency / MODULATION_CLOCK if self.frequency > 0 else
                  self.frequency / MODULATION_CLOCK + 4) * 2**28)
         elif (self.instruction == "SET_PHASE") | (
                 self.instruction == "UPDATE_FRAME"):
             #phases can span -0.5 to 0.5 or 0 to 1 in unsigned
-            payload |= np.uint32(np.mod(self.phase / (2 * np.pi), 1) * 2**28)
+            payload |= np.uint64(np.mod(self.phase / (2 * np.pi), 1) * 2**28)
 
         instr = Instruction(MODULATION << 4, payload, label)
         instr.writeFlag = write_flag

--- a/QGL/drivers/APS3Pattern.py
+++ b/QGL/drivers/APS3Pattern.py
@@ -590,16 +590,16 @@ class ModulationCommand(object):
             self.nco_select << NCO_SELECT_OP_OFFSET)
         if self.instruction == "MODULATE":
             #zero-indexed quad count
-            payload |= np.uint32(self.length / ADDRESS_UNIT - 1)
+            payload |= np.uint64(self.length / ADDRESS_UNIT - 1)
         elif self.instruction == "SET_FREQ":
             # frequencies can span -4 to 4 or 0 to 8 in unsigned
-            payload |= np.uint32(
+            payload |= np.uint64(
                 (self.frequency / MODULATION_CLOCK if self.frequency > 0 else
                  self.frequency / MODULATION_CLOCK + 8) * 2**27)
         elif (self.instruction == "SET_PHASE") | (
                 self.instruction == "UPDATE_FRAME"):
             #phases can span -0.5 to 0.5 or 0 to 1 in unsigned
-            payload |= np.uint32(np.mod(self.phase / (2 * np.pi), 1) * 2**27)
+            payload |= np.uint64(np.mod(self.phase / (2 * np.pi), 1) * 2**27)
 
         instr = Instruction(MODULATION << 4, payload, label)
         instr.writeFlag = write_flag


### PR DESCRIPTION
Changed uint32 to uint64 in APS2 and APS3 drivers. uint32 causes overflow in numpy 2.0, because of the |= operator with the initial payload which has 44 bits.